### PR TITLE
Add journals

### DIFF
--- a/royal-society/_journals.tab
+++ b/royal-society/_journals.tab
@@ -6,4 +6,4 @@ Open Biology		2046-2441	http://rsob.royalsocietypublishing.org/site/misc/stylean
 Philosophical Transactions of the Royal Society A	1364-503X	1471-2962	http://rsta.royalsocietypublishing.org/site/misc/style-guide.xhtml#question9	physics
 Philosophical Transactions of the Royal Society B	0962-8436	1471-2970	http://rstb.royalsocietypublishing.org/	biology
 Proceedings of the Royal Society A	1364-5021	1471-2946	http://rspa.royalsocietypublishing.org/site/misc/preparing-your-article.xhtml#question3	physics
-Royal Society Open Science	2054-5703	x	https://royalsociety.org/journals/authors/author-guidelines/	science
+Royal Society Open Science	x	2054-5703	https://royalsociety.org/journals/authors/author-guidelines/	science

--- a/royal-society/_journals.tab
+++ b/royal-society/_journals.tab
@@ -1,9 +1,9 @@
-Title	ISSN	eISSN	Documentation	Field
-Biology Letters	1744-9561	1744-957X	http://rsbl.royalsocietypublishing.org/site/misc/styleandpolicy.xhtml#question3	biology
-Interface Focus	2042-8898	2042-8901	http://rsif.royalsocietypublishing.org/site/misc/preparing-articles.xhtml#question8	science
-Journal of the Royal Society Interface	1742-5689	1742-5662	http://rsif.royalsocietypublishing.org/site/misc/preparing-articles.xhtml#question8	science
-Open Biology		2046-2441	http://rsob.royalsocietypublishing.org/site/misc/styleandpolicy.xhtml#question10	biology
-Philosophical Transactions of the Royal Society A	1364-503X	1471-2962	http://rsta.royalsocietypublishing.org/site/misc/style-guide.xhtml#question9	physics
-Philosophical Transactions of the Royal Society B	0962-8436	1471-2970	http://rstb.royalsocietypublishing.org/	biology
-Proceedings of the Royal Society A	1364-5021	1471-2946	http://rspa.royalsocietypublishing.org/site/misc/preparing-your-article.xhtml#question3	physics
-Royal Society Open Science	x	2054-5703	https://royalsociety.org/journals/authors/author-guidelines/	science
+Title	ISSN	eISSN	Field
+Biology Letters	1744-9561	1744-957X	biology
+Interface Focus	2042-8898	2042-8901	science
+Journal of the Royal Society Interface	1742-5689	1742-5662	science
+Open Biology	x	2046-2441	biology
+Philosophical Transactions of the Royal Society A	1364-503X	1471-2962	physics
+Philosophical Transactions of the Royal Society B	0962-8436	1471-2970	biology
+Proceedings of the Royal Society A	1364-5021	1471-2946	physics
+Royal Society Open Science	x	2054-5703	science

--- a/royal-society/_journals.tab
+++ b/royal-society/_journals.tab
@@ -7,5 +7,3 @@ Philosophical Transactions of the Royal Society A	1364-503X	1471-2962	http://rst
 Philosophical Transactions of the Royal Society B	0962-8436	1471-2970	http://rstb.royalsocietypublishing.org/	biology
 Proceedings of the Royal Society A	1364-5021	1471-2946	http://rspa.royalsocietypublishing.org/site/misc/preparing-your-article.xhtml#question3	physics
 Royal Society Open Science	2054-5703	x	https://royalsociety.org/journals/authors/author-guidelines/	science
-Proceedings of the Royal Society B	1364-5021	1471-2946	https://royalsociety.org/journals/authors/author-guidelines/	biology
-Notes and Records: the Royal Society Journal of the History of Science	0035-9149	1743-0178	https://royalsociety.org/journals/authors/author-guidelines/	history

--- a/royal-society/_journals.tab
+++ b/royal-society/_journals.tab
@@ -6,3 +6,6 @@ Open Biology		2046-2441	http://rsob.royalsocietypublishing.org/site/misc/stylean
 Philosophical Transactions of the Royal Society A	1364-503X	1471-2962	http://rsta.royalsocietypublishing.org/site/misc/style-guide.xhtml#question9	physics
 Philosophical Transactions of the Royal Society B	0962-8436	1471-2970	http://rstb.royalsocietypublishing.org/	biology
 Proceedings of the Royal Society A	1364-5021	1471-2946	http://rspa.royalsocietypublishing.org/site/misc/preparing-your-article.xhtml#question3	physics
+Royal Society Open Science	2054-5703	x	https://royalsociety.org/journals/authors/author-guidelines/	science
+Proceedings of the Royal Society B	1364-5021	1471-2946	https://royalsociety.org/journals/authors/author-guidelines/	biology
+Notes and Records: the Royal Society Journal of the History of Science	0035-9149	1743-0178	https://royalsociety.org/journals/authors/author-guidelines/	history

--- a/royal-society/_template.csl
+++ b/royal-society/_template.csl
@@ -6,12 +6,12 @@
     <id>http://www.zotero.org/styles/#IDENTIFIER#</id>
     <link href="http://www.zotero.org/styles/#IDENTIFIER#" rel="self"/>
     <link href="http://www.zotero.org/styles/proceedings-of-the-royal-society-b" rel="independent-parent"/>
-    <link href="#DOCUMENTATION#" rel="documentation"/>
+    <link href="https://royalsociety.org/journals/authors/author-guidelines/" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="#FIELD#"/>
     <issn>#ISSN#</issn>
     <eissn>#EISSN#</eissn>
-    <updated>2014-06-11T12:00:00+00:00</updated>
+    <updated>2017-01-05T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>


### PR DESCRIPTION
All but their Memoirs journal follow the same style.
The urls for the journals already in there don't work anymore. We could add this generic link into the template and delete the "documentation" column here?