### PR TITLE
Update _journals.tab for NRC journals

### DIFF
--- a/nrc/_journals.tab
+++ b/nrc/_journals.tab
@@ -1,4 +1,7 @@
 TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	INDEPENDENT
+Applied Physiology, Nutrition, and Metabolism 1715-5312 http://www.nrcresearchpress.com/page/apnm/authors medicine  biology canadian-journal-of-fisheries-and-aquatic-sciences
+Arctic Science  2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science x canadian-journal-of-soil-science
+Canadian Journal of Microbiology  1480-3275  0008-4166  http://www.nrcresearchpress.com/page/cjm/authors  biology medicine  canadian-journal-of-fisheries-and-aquatic-sciences
 Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	canadian-journal-of-fisheries-and-aquatic-sciences
 Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences
 Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences

--- a/nrc/_journals.tab
+++ b/nrc/_journals.tab
@@ -1,16 +1,16 @@
-TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	INDEPENDENT FORMAT
-Applied Physiology, Nutrition, and Metabolism 1715-5312 http://www.nrcresearchpress.com/page/apnm/authors medicine  biology canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Arctic Science  2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science x canadian-journal-of-soil-science  author-date
-Canadian Journal of Microbiology  1480-3275  0008-4166  http://www.nrcresearchpress.com/page/cjm/authors  biology medicine  canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Biochemistry and Cell Biology	0829-8211	1208-6002	http://www.nrcresearchpress.com/page/bcb/authors	medicine	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
-Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	canadian-geotechnical-journal  author-date
-Canadian Journal of Animal Science	0008-3984	1918-1825	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	zoology	x	canadian-journal-of-soil-science  author-date
-Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	canadian-journal-of-soil-science  author-date
-Canadian Journal of Physiology and Pharmacology 0008-4212 1205-7541 http://www.nrcresearchpress.com/page/cjpp/authors#9d  medicine  x apa author-date
-Canadian Journal of Chemistry 0008-4042 1480-3291 http://www.nrcresearchpress.com/page/cjc/authors  chemistry x american-chemical-society-page-first  numeric
+TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	FORMAT	PARENT
+Applied Physiology, Nutrition, and Metabolism	1715-5312	1715-5320	http://www.nrcresearchpress.com/page/apnm/authors	medicine	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Arctic Science	2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science	x	author-date	canadian-journal-of-soil-science
+Canadian Journal of Microbiology	1480-3275	0008-4166	http://www.nrcresearchpress.com/page/cjm/authors	biology	medicine	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Biochemistry and Cell Biology	0829-8211	1208-6002	http://www.nrcresearchpress.com/page/bcb/authors	medicine	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	author-date	canadian-geotechnical-journal
+Canadian Journal of Animal Science	0008-3984	1918-1825	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	zoology	x	author-date	canadian-journal-of-soil-science
+Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	author-date	canadian-journal-of-soil-science
+Canadian Journal of Physiology and Pharmacology	0008-4212	1205-7541	http://www.nrcresearchpress.com/page/cjpp/authors#9d	medicine	x	author-date	apa
+Canadian Journal of Chemistry	0008-4042	1480-3291	http://www.nrcresearchpress.com/page/cjc/authors	chemistry	x	numeric	american-chemical-society-page-first

--- a/nrc/_journals.tab
+++ b/nrc/_journals.tab
@@ -1,14 +1,16 @@
-TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	INDEPENDENT
-Applied Physiology, Nutrition, and Metabolism 1715-5312 http://www.nrcresearchpress.com/page/apnm/authors medicine  biology canadian-journal-of-fisheries-and-aquatic-sciences
-Arctic Science  2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science x canadian-journal-of-soil-science
-Canadian Journal of Microbiology  1480-3275  0008-4166  http://www.nrcresearchpress.com/page/cjm/authors  biology medicine  canadian-journal-of-fisheries-and-aquatic-sciences
-Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	canadian-journal-of-fisheries-and-aquatic-sciences
-Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences
-Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	canadian-journal-of-fisheries-and-aquatic-sciences
-Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences
-Biochemistry and Cell Biology	0829-8211	1208-6002	http://www.nrcresearchpress.com/page/bcb/authors	medicine	biology	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	canadian-geotechnical-journal
-Canadian Journal of Animal Science	0008-3984	1918-1825	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	zoology	x	canadian-journal-of-soil-science
-Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	canadian-journal-of-soil-science
+TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	INDEPENDENT FORMAT
+Applied Physiology, Nutrition, and Metabolism 1715-5312 http://www.nrcresearchpress.com/page/apnm/authors medicine  biology canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Arctic Science  2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science x canadian-journal-of-soil-science  author-date
+Canadian Journal of Microbiology  1480-3275  0008-4166  http://www.nrcresearchpress.com/page/cjm/authors  biology medicine  canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Biochemistry and Cell Biology	0829-8211	1208-6002	http://www.nrcresearchpress.com/page/bcb/authors	medicine	biology	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	canadian-journal-of-fisheries-and-aquatic-sciences  author-date
+Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	canadian-geotechnical-journal  author-date
+Canadian Journal of Animal Science	0008-3984	1918-1825	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	zoology	x	canadian-journal-of-soil-science  author-date
+Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	canadian-journal-of-soil-science  author-date
+Canadian Journal of Physiology and Pharmacology 0008-4212 1205-7541 http://www.nrcresearchpress.com/page/cjpp/authors#9d  medicine  x apa author-date
+Canadian Journal of Chemistry 0008-4042 1480-3291 http://www.nrcresearchpress.com/page/cjc/authors  chemistry x american-chemical-society-page-first  numeric

--- a/nrc/_journals.tab
+++ b/nrc/_journals.tab
@@ -1,16 +1,16 @@
 TITLE	ISSN	EISSN	DOCUMENTATION	FIELD1	FIELD2	FORMAT	PARENT
 Applied Physiology, Nutrition, and Metabolism	1715-5312	1715-5320	http://www.nrcresearchpress.com/page/apnm/authors	medicine	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
 Arctic Science	2368-7460	x	http://www.nrcresearchpress.com/page/as/authors	science	x	author-date	canadian-journal-of-soil-science
-Canadian Journal of Microbiology	1480-3275	0008-4166	http://www.nrcresearchpress.com/page/cjm/authors	biology	medicine	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
 Biochemistry and Cell Biology	0829-8211	1208-6002	http://www.nrcresearchpress.com/page/bcb/authors	medicine	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
-Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	author-date	canadian-geotechnical-journal
+Botany	1916-2790	1916-2804	http://www.nrcresearchpress.com/page/cjb/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
 Canadian Journal of Animal Science	0008-3984	1918-1825	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	zoology	x	author-date	canadian-journal-of-soil-science
-Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	author-date	canadian-journal-of-soil-science
-Canadian Journal of Physiology and Pharmacology	0008-4212	1205-7541	http://www.nrcresearchpress.com/page/cjpp/authors#9d	medicine	x	author-date	apa
 Canadian Journal of Chemistry	0008-4042	1480-3291	http://www.nrcresearchpress.com/page/cjc/authors	chemistry	x	numeric	american-chemical-society-page-first
+Canadian Journal of Civil Engineering	0315-1468	1208-6029	http://www.nrcresearchpress.com/page/cjce/authors	engineering	x	author-date	canadian-geotechnical-journal
+Canadian Journal of Forest Research	0045-5067	1208-6037	http://www.nrcresearchpress.com/page/cjfr/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Canadian Journal of Microbiology	1480-3275	0008-4166	http://www.nrcresearchpress.com/page/cjm/authors	biology	medicine	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Canadian Journal of Physiology and Pharmacology	0008-4212	1205-7541	http://www.nrcresearchpress.com/page/cjpp/authors#9d	medicine	x	author-date	apa
+Canadian Journal of Plant Science	0008-4220	1918-1833	http://www.aic.ca/journals/pdf/Instructions/Operations_Manual_Revised_2012.pdf	biology	botany	author-date	canadian-journal-of-soil-science
+Canadian Journal of Zoology	0008-4301	1480-3283	http://www.nrcresearchpress.com/page/cjz/authors	zoology	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Environmental Reviews	1181-8700	1208-6053	http://www.nrcresearchpress.com/page/er/authors	science	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Genome	0831-2796	1480-3321	http://www.nrcresearchpress.com/page/gen/authors	botany	biology	author-date	canadian-journal-of-fisheries-and-aquatic-sciences
+Journal of Unmanned Vehicle Systems	x	2291-3467	http://www.nrcresearchpress.com/page/juvs/authors	engineering	x	author-date	canadian-journal-of-fisheries-and-aquatic-sciences

--- a/nrc/_template.csl
+++ b/nrc/_template.csl
@@ -5,7 +5,7 @@
     <title>#TITLE#</title>
     <id>http://www.zotero.org/styles/#IDENTIFIER#</id>
     <link href="http://www.zotero.org/styles/#IDENTIFIER#" rel="self"/>
-    <link href="http://www.zotero.org/styles/#INDEPENDENT#" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/#PARENT#" rel="independent-parent"/>
     <link href="#DOCUMENTATION#" rel="documentation"/>
     <category citation-format="#FORMAT#"/>
     <category field="#FIELD1#"/>

--- a/nrc/_template.csl
+++ b/nrc/_template.csl
@@ -7,12 +7,12 @@
     <link href="http://www.zotero.org/styles/#IDENTIFIER#" rel="self"/>
     <link href="http://www.zotero.org/styles/#INDEPENDENT#" rel="independent-parent"/>
     <link href="#DOCUMENTATION#" rel="documentation"/>
-    <category citation-format="author-date"/>
+    <category citation-format="#FORMAT#"/>
     <category field="#FIELD1#"/>
     <category field="#FIELD2#"/>
     <issn>#ISSN#</issn>
     <eissn>#EISSN#</eissn>
-    <updated>2016-05-28T12:00:00+00:00</updated>
+    <updated>2017-01-11T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>


### PR DESCRIPTION
Add 3 journals following one of the two independent parents as requested here https://github.com/citation-style-language/journals/issues/10
applied-physiology-nutrition-and-metabolism has existed as its own dependent style and should be deleted.
(it's not alphabetic. Happy to sort it out if want)