### PR TITLE
Add "Reviews of Environmental Contamination and Toxicology" to Springer's _extra.tab

### DIFF
--- a/springer/_extra.tab
+++ b/springer/_extra.tab
@@ -24,5 +24,6 @@ Pflügers Archiv - European Journal of Physiology	Pflugers Arch - Eur J Physiol	
 Plant Ecology	Plant Ecol	1385-0237	1573-5052	springer-basic-author-date-no-et-al	author-date	science	en-US
 Plant Molecular Biology	Plant Mol Biol	0167-4412	1573-5028	springer-basic-author-date-no-et-al	author-date	science	en-US
 Research in the Mathematical Sciences			2197-9847	springer-mathphys-brackets	numeric		en-US
+Reviews of Environmental Contamination	Rev Environ Contam Toxicol	0179-5953	x	springer-basic-author-date	author-date	science	en-US
 Springer Science Reviews	Springer Science Reviews		2213-7793	springer-basic-brackets	numeric	science	en-US
 Surgical Endoscopy	Surg Endosc	0930-2794	1432-2218	springer-basic-brackets-no-et-al	numeric	science	en-US

--- a/springer/_extra.tab
+++ b/springer/_extra.tab
@@ -24,6 +24,6 @@ Pflügers Archiv - European Journal of Physiology	Pflugers Arch - Eur J Physiol	
 Plant Ecology	Plant Ecol	1385-0237	1573-5052	springer-basic-author-date-no-et-al	author-date	science	en-US
 Plant Molecular Biology	Plant Mol Biol	0167-4412	1573-5028	springer-basic-author-date-no-et-al	author-date	science	en-US
 Research in the Mathematical Sciences			2197-9847	springer-mathphys-brackets	numeric		en-US
-Reviews of Environmental Contamination	Rev Environ Contam Toxicol	0179-5953	x	springer-basic-author-date	author-date	science	en-US
+Reviews of Environmental Contamination and Toxicology	Rev Environ Contam Toxicol	0179-5953	x	springer-basic-author-date	author-date	science	en-US
 Springer Science Reviews	Springer Science Reviews		2213-7793	springer-basic-brackets	numeric	science	en-US
 Surgical Endoscopy	Surg Endosc	0930-2794	1432-2218	springer-basic-brackets-no-et-al	numeric	science	en-US


### PR DESCRIPTION
Just follows the basic Sprinter author-date style.
Per request here: https://github.com/citation-style-language/styles/issues/2238