### PR TITLE
Update Elsevier skip list

### DIFF
--- a/elsevier/_skip.txt
+++ b/elsevier/_skip.txt
@@ -1,6 +1,9 @@
 # Require custom style
 organic-geochemistry
 
+# 2017-07: https://github.com/citation-style-language/styles/pull/2823
+resuscitation
+
 # 2017-03: https://github.com/citation-style-language/styles/pull/2570
 asian-pacific-journal-of-tropical-disease
 


### PR DESCRIPTION
Also,
the-american-journal-of-human-genetics
and molecular-plant do now exist in the repository. I'll let you sort that the way you want.