### PR TITLE
Updates _journals.tab for Elsevier journals

### DIFF
--- a/elsevier/_journals.tab
+++ b/elsevier/_journals.tab
@@ -1,14 +1,17 @@
 Title	ISSN	Parent	Format
 Acta Astronautica	0094-5765	elsevier-with-titles	numeric
+Aquaculture and Fisheries	2468-550X	apa	author-date
 Annals of Anatomy	0940-9602	elsevier-harvard	author-date
 Accident Analysis and Prevention	0001-4575	elsevier-harvard	author-date
 Annals of Agrarian Science	1512-1887	elsevier-with-titles	numeric
-AASRI Procedia	2212-6716	elsevier-with-titles	numeric
 Addictive Behaviors	0306-4603	apa	author-date
 Addictive Behaviors Reports	2352-8532	apa	author-date
+Advances in Biomarker Sciences and Technology	2543-1064	american-medical-association	numeric
 Analytica Chimica Acta	0003-2670	elsevier-with-titles	numeric
+Applied Computing and Geosciences	2590-1974	elsevier-harvard	author-date
 The Journal of Academic Librarianship	0099-1333	apa	author-date
 Academic Pediatrics	1876-2859	american-medical-association	numeric
+Analytica Chimica Acta: X	2590-1346	elsevier-with-titles	numeric
 Journal of International Accounting, Auditing and Taxation	1061-9518	apa	author-date
 Journal of Accounting Education	0748-5751	apa	author-date
 Accounting Forum	0155-9982	apa	author-date
@@ -17,10 +20,8 @@ Journal of Accounting Literature	0737-4607	apa	author-date
 International Journal of Accounting	0020-7063	apa	author-date
 Anaesthesia Critical Care & Pain Medicine	2352-5568	elsevier-vancouver	numeric
 Advances in Climate Change Research	1674-9278	elsevier-harvard	author-date
-Acta Haematologica Polonica	0001-5814	elsevier-vancouver	numeric
-Applied Computing and Informatics	2210-8327	elsevier-harvard	author-date
+Applied Computing and Informatics	2210-8327	elsevier-with-titles	numeric
 Archives of Civil and Mechanical Engineering	1644-9665	elsevier-with-titles	numeric
-Acta Sociológica	0186-6028	apa	author-date
 Acta Biomaterialia	1742-7061	elsevier-with-titles	numeric
 Acta Histochemica	0065-1281	elsevier-harvard	author-date
 Acta Oecologica	1146-609X	elsevier-harvard	author-date
@@ -28,12 +29,12 @@ Actualités pharmaceutiques	0515-3700	elsevier-vancouver	numeric
 Acta Psychologica	0001-6918	apa	author-date
 Acta Tropica	0001-706X	elsevier-harvard	author-date
 Archives of Cardiovascular Diseases	1875-2136	elsevier-vancouver	numeric
-Annales de Chirurgie Vasculaire	0299-2213	elsevier-vancouver	numeric
+Archives of Cardiovascular Diseases Supplements	1878-6480	elsevier-vancouver	numeric
 The Journal of the American Dental Association	0002-8177	american-medical-association	numeric
 Additive Manufacturing	2214-8604	elsevier-with-titles	numeric
 Advances in Engineering Software	0965-9978	elsevier-vancouver	numeric
 Ad Hoc Networks	1570-8705	elsevier-with-titles	numeric
-Advances in Accounting, incorporating Advances in International Accounting	0882-6110	apa	author-date
+Advances in Accounting	0882-6110	apa	author-date
 Archives des Maladies Professionnelles et de l'Environnement	1775-8785	elsevier-vancouver	numeric
 Advanced Drug Delivery Reviews	0169-409X	elsevier-with-titles	numeric
 Advances in Radiation Oncology	2452-1094	american-medical-association	numeric
@@ -41,15 +42,15 @@ Advanced Engineering Informatics	1474-0346	elsevier-with-titles	numeric
 Advances in Medical Sciences	1896-1126	elsevier-vancouver	numeric
 Advances in Water Resources	0309-1708	elsevier-harvard	author-date
 Atmospheric Environment	1352-2310	elsevier-harvard	author-date
+Atmospheric Environment: X	2590-1621	elsevier-harvard	author-date
 Arab Economic and Business Journal	2214-4625	apa	author-date
 Alexandria Engineering Journal	1110-0168	elsevier-with-titles	numeric
-Australasian Emergency Nursing Journal	1574-6267	elsevier-vancouver	numeric
 Aeolian Research	1875-9637	elsevier-harvard	author-date
 Annals of Epidemiology	1047-2797	elsevier-vancouver	numeric
 Journal of African Earth Sciences	1464-343X	elsevier-harvard	author-date
 Aerospace Science and Technology	1270-9638	elsevier-with-titles	numeric
 AEUE - International Journal of Electronics and Communications	1434-8411	elsevier-vancouver	numeric
-Atención Familiar	1405-8871	elsevier-vancouver	numeric
+African Journal of Emergency Medicine	2211-419X	elsevier-vancouver	numeric
 African Journal of Urology	1110-5704	elsevier-vancouver	numeric
 Annales françaises d’oto-rhino-laryngologie et de pathologie cervico-faciale	1879-7261	elsevier-vancouver	numeric
 Osteoporosis and Sarcopenia	2405-5255	elsevier-vancouver	numeric
@@ -61,27 +62,26 @@ Journal of Aging Studies	0890-4065	apa	author-date
 Agricultural and Forest Meteorology	0168-1923	elsevier-harvard	author-date
 Agricultural Systems	0308-521X	elsevier-harvard	author-date
 Agricultural Water Management	0378-3774	elsevier-harvard	author-date
-Advances in Digestive Medicine	2351-9797	elsevier-vancouver	numeric
 L'aide-soignante	1166-3413	elsevier-vancouver	numeric
+Advanced Industrial and Engineering Polymer Research	2542-5048	elsevier-with-titles	numeric
+Artificial Intelligence in Agriculture	2589-7217	elsevier-harvard	author-date
 Advances in Integrative Medicine	2212-9588	elsevier-with-titles	numeric
 The Arts in Psychotherapy	0197-4556	apa	author-date
-Acta de Investigación Psicológica	2007-4719	apa	author-date
 Arab Journal of Gastroenterology	1687-1979	elsevier-vancouver	numeric
-American Journal of Geriatric Pharmacotherapy	1543-5946	american-medical-association	numeric
 The American Journal of Human Genetics	0002-9297	elsevier-vancouver	numeric
-Asian Journal of Health Sciences	1878-5263	elsevier-with-titles	numeric
 The American Journal of Medicine	0002-9343	american-medical-association	numeric
+Alexandria Journal of Medicine	2090-5068	american-medical-association	numeric
 American Journal of Ophthalmology Case Reports	2451-9936	american-medical-association	numeric
+American Journal of Ophthalmology	0002-9394	american-medical-association	numeric
 Asian Journal of Psychiatry	1876-2018	elsevier-harvard	author-date
+Asian Journal of Pharmaceutical Sciences	1818-0876	elsevier-vancouver	numeric
+The American Journal of Surgery	0002-9610	american-medical-association	numeric
 The Asian Journal of Shipping and Logistics	2092-5212	apa	author-date
 Asian Journal of Urology	2214-3882	elsevier-vancouver	numeric
 AKCE International Journal of Graphs and Combinatorics	0972-8600	elsevier-with-titles	numeric
 Alcohol	0741-8329	apa	author-date
 Advances in Life Course Research	1040-2608	apa	author-date
-Alergologia Polska- Polish Journal of Allergology	2353-3854	elsevier-vancouver	numeric
 Algal Research	2211-9264	elsevier-with-titles	numeric
-Alcoholism and Drug Addiction	0867-4361	elsevier-vancouver	numeric
-Achievements in the Life Sciences	2078-1520	elsevier-harvard	author-date
 Alter - European Journal of Disability research, Revue européenne de recherche sur le handicap	1875-0672	apa	author-date
 Acta Materialia	1359-6454	elsevier-with-titles	numeric
 Analytic Methods in Accident Research	2213-6657	elsevier-harvard	author-date
@@ -96,28 +96,22 @@ Annals of Medicine and Surgery	2049-0801	elsevier-with-titles	numeric
 Annals of Allergy, Asthma & Immunology	1081-1206	american-medical-association	numeric
 Annales de cardiologie et d'angéiologie	0003-3928	elsevier-vancouver	numeric
 Anthropocene	2213-3054	elsevier-harvard	author-date
-Analytical Chemistry Research	2214-1812	elsevier-with-titles	numeric
 Annales d'Endocrinologie	0003-4266	elsevier-vancouver	numeric
 Annals of Nuclear Energy	0306-4549	elsevier-harvard	author-date
-Animal Gene	2352-4065	elsevier-harvard	author-date
 Animal Feed Science and Technology	0377-8401	elsevier-harvard	author-date
 Annales de l'Institut Henri Poincaré / Analyse non linéaire	0294-1449	elsevier-with-titles	numeric
-Animal Nutrition	2405-6545	elsevier-vancouver-author-date	author-date
+Animal Nutrition	2405-6545	vancouver-author-date	author-date
 Animal Reproduction Science	0378-4320	elsevier-harvard	author-date
 Auris Nasus Larynx	0385-8146	elsevier-vancouver	numeric
 Annales de Dermatologie et de Vénéréologie	0151-9638	elsevier-vancouver	numeric
-Annales Françaises d'Anesthésie et de Réanimation	0750-7658	elsevier-vancouver	numeric
 Annales de Paléontologie	0753-3969	elsevier-harvard	author-date
 Annales de Pathologie	0242-6498	elsevier-vancouver	numeric
 Annales de chirurgie plastique esthétique	0294-1260	elsevier-vancouver	numeric
 European Annals of Otorhinolaryngology, Head and Neck diseases	1879-7296	elsevier-vancouver	numeric
-Anuario de Psicología	0066-5126	apa	author-date
 Anesthésie & Réanimation	2352-5800	elsevier-vancouver	numeric
 Agriculture and Natural Resources	2452-316X	elsevier-harvard	author-date
 International Journal of Antimicrobial Agents	0924-8579	elsevier-vancouver	numeric
 L'Anthropologie	0003-5521	elsevier-harvard	author-date
-Journal des Anti-infectieux	2210-6545	elsevier-vancouver	numeric
-Anales de Antropología	0185-1225	apa	author-date
 Journal of Anxiety Disorders	0887-6185	apa	author-date
 Ansiedad y Estrés	1134-7937	apa	author-date
 Annals of Agricultural Sciences	0570-1783	elsevier-harvard	author-date
@@ -125,16 +119,11 @@ Archives of Oral Biology	0003-9969	apa	author-date
 Annals of Global Health	2214-9996	american-medical-association	numeric
 AORN Journal	0001-2092	american-medical-association	numeric
 Accounting, Organizations and Society	0361-3682	apa	author-date
-Acta Orthopaedica et Traumatologica Turcica	1017-995X	american-medical-association	numeric
 Applied Acoustics	0003-682X	elsevier-vancouver	numeric
 Applied Catalysis A, General	0926-860X	elsevier-without-titles	numeric
 Applied Catalysis B: Environmental	0926-3373	elsevier-with-titles	numeric
-APCBEE Procedia	2212-6708	elsevier-with-titles	numeric
 Applied Energy	0306-2619	elsevier-vancouver	numeric
-Anuario de Psicología Jurídica	1133-0740	apa	author-date
-Asian Pacific Journal of Tropical Disease	2222-1808	elsevier-vancouver-author-date	author-date
 Applied Mathematical Modelling	0307-904X	elsevier-with-titles	numeric
-Apollo Medicine	0976-0016	american-medical-association	numeric
 Asia Pacific Management Review	1029-3132	apa	author-date
 Applied Materials Today	2352-9407	elsevier-with-titles	numeric
 Applied Ocean Research	0141-1187	elsevier-with-titles	numeric
@@ -147,8 +136,6 @@ Applied Soil Ecology	0929-1393	elsevier-harvard	author-date
 Applied Surface Science	0169-4332	elsevier-with-titles	numeric
 Advanced Powder Technology	0921-8831	elsevier-with-titles	numeric
 Aquatic Botany	0304-3770	elsevier-harvard	author-date
-Aquatic Data	2468-1318	elsevier-harvard	author-date
-Aquatic Procedia	2214-241X	elsevier-harvard	author-date
 Aquaculture Reports	2352-5134	elsevier-harvard	author-date
 Aquatic Toxicology	0166-445X	elsevier-harvard	author-date
 Aquaculture	0044-8486	elsevier-harvard	author-date
@@ -158,8 +145,8 @@ Arabian Journal of Chemistry	1878-5352	elsevier-harvard	author-date
 Archives de pédiatrie	0929-693X	elsevier-vancouver	numeric
 Applied Radiation and Isotopes	0969-8043	elsevier-harvard	author-date
 Ageing Research Reviews	1568-1637	elsevier-harvard	author-date
+Array	2590-0056	elsevier-vancouver	numeric
 Arthroplasty Today	2352-3441	elsevier-vancouver	numeric
-Acupuncture and Related Therapies	2211-7660	elsevier-with-titles	numeric
 Artificial Intelligence	0004-3702	elsevier-with-titles	numeric
 Artificial Intelligence In Medicine	0933-3657	elsevier-vancouver	numeric
 Journal of Aerosol Science	0021-8502	apa	author-date
@@ -175,14 +162,14 @@ Astroparticle Physics	0927-6505	elsevier-with-titles	numeric
 New Astronomy Reviews	1387-6473	elsevier-harvard	author-date
 Assessing Writing	1075-2935	apa	author-date
 Applied Thermal Engineering	1359-4311	elsevier-with-titles	numeric
-Applied & Translational Genomics	2212-0661	elsevier-harvard	author-date
 Atherosclerosis	0021-9150	elsevier-with-titles	numeric
 Atherosclerosis (Supplements) (Component)	1567-5688	elsevier-vancouver	numeric
+Atherosclerosis: X	2590-1354	elsevier-with-titles	numeric
 Atmospheric Research	0169-8095	elsevier-harvard	author-date
 Journal of Atmospheric and Solar-Terrestrial Physics	1364-6826	elsevier-harvard	author-date
 Annals of Tourism Research	0160-7383	apa	author-date
 The Annals of Thoracic Surgery	0003-4975	elsevier-vancouver	numeric
-Aula Abierta	0210-2773	apa	author-date
+Australasian Emergency Care	2588-994X	elsevier-vancouver	numeric
 Automatica	0005-1098	apa	author-date
 Automation in Construction	0926-5805	elsevier-with-titles	numeric
 Autonomic Neuroscience: Basic and Clinical	1566-0702	elsevier-harvard	author-date
@@ -194,7 +181,6 @@ Building and Environment	0360-1323	elsevier-with-titles	numeric
 Basal Ganglia	2210-5336	elsevier-with-titles	numeric
 BBA - Bioenergetics	0005-2728	elsevier-with-titles	numeric
 BBA - Reviews on Cancer	0304-419X	elsevier-with-titles	numeric
-BBA Clinical	2214-6474	elsevier-with-titles	numeric
 BBA - Molecular Basis of Disease	0925-4439	elsevier-with-titles	numeric
 BBA - General Subjects	0304-4165	elsevier-with-titles	numeric
 BBA - Gene Regulatory Mechanisms	1874-9399	elsevier-with-titles	numeric
@@ -214,34 +200,37 @@ Big Data Research	2214-5796	elsevier-with-titles	numeric
 Biochemical Engineering Journal	1369-703X	elsevier-with-titles	numeric
 Behavioural Processes	0376-6357	elsevier-harvard	author-date
 Behavior Therapy	0005-7894	apa	author-date
-Biomarkers and Genomic Medicine	2214-0247	american-medical-association	numeric
+Bulletin of Faculty of Pharmacy, Cairo University	1110-0931	elsevier-with-titles	numeric
 Biologically Inspired Cognitive Architectures	2212-683X	apa	author-date
 BioSystems	0303-2647	elsevier-harvard	author-date
 Biological Conservation	0006-3207	elsevier-harvard	author-date
 Biophysical Chemistry	0301-4622	elsevier-with-titles	numeric
 Biochimie	0300-9084	elsevier-with-titles	numeric
 BIOETHICS UPdate	2395-938X	apa	author-date
+Biofilm	2590-2075	elsevier-vancouver	numeric
 Bioelectrochemistry	1567-5394	elsevier-with-titles	numeric
 International Journal of Biological Macromolecules	0141-8130	elsevier-with-titles	numeric
-Biomedicine & Aging Pathology	2210-5220	elsevier-vancouver	numeric
 Bioactive Materials	2452-199X	elsevier-with-titles	numeric
-BioMedicine	2211-8020	elsevier-vancouver	numeric
-Biomedicine & Preventive Nutrition	2210-5239	elsevier-vancouver	numeric
 Biochimie Open	2214-0085	elsevier-with-titles	numeric
 Biomedicine & Pharmacotherapy	0753-3322	elsevier-with-titles	numeric
 Biological Psychology	0301-0511	apa	author-date
 Biotechnology Research and Innovation	2452-0721	apa	author-date
 Biosensors and Bioelectronics	0956-5663	elsevier-harvard	author-date
+Biosensors and Bioelectronics: X	2590-1370	elsevier-harvard	author-date
 Journal of Biotechnology	0168-1656	elsevier-harvard	author-date
 Biotribology	2352-5738	elsevier-with-titles	numeric
 Borsa Istanbul Review	2214-8450	apa	author-date
 Bioresource Technology	0960-8524	elsevier-harvard	author-date
+Bioresource Technology Reports	2589-014X	elsevier-harvard	author-date
 Biomedical Journal	2319-4170	elsevier-vancouver	numeric
-Beni-Suef University Journal of Basic and Applied Sciences	2314-8535	elsevier-vancouver-author-date	author-date
+Beni-Suef University Journal of Basic and Applied Sciences	2314-8535	elsevier-harvard	author-date
 Brazilian Journal of Microbiology	1517-8382	american-medical-association	numeric
 Revista Brasileira de Farmacognosia	0102-695X	elsevier-harvard	author-date
+Brazilian Journal of Physical Therapy	1413-3555	american-medical-association	numeric
 Interbloc	0242-3960	elsevier-vancouver	numeric
 Journal of Biomechanics	0021-9290	elsevier-harvard	author-date
+Bioorganic & Medicinal Chemistry	0968-0896	american-medical-association	numeric
+Bioorganic & Medicinal Chemistry Letters	0960-894X	american-medical-association	numeric
 Body Image	1740-1445	apa	author-date
 Bone	8756-3282	elsevier-with-titles	numeric
 Bone Reports	2352-1872	elsevier-harvard	author-date
@@ -253,22 +242,25 @@ Brain Research	0006-8993	elsevier-harvard	author-date
 BRQ Business Research Quarterly	2340-9436	elsevier-harvard	author-date
 Brain Stimulation	1935-861X	elsevier-vancouver	numeric
 Behaviour Research and Therapy	0005-7967	apa	author-date
-Biosurface and Biotribology	2405-4518	elsevier-with-titles	numeric
 Biochemical Systematics and Ecology	0305-1978	elsevier-harvard	author-date
 Boletín de la Sociedad Española de Cerámica y Vidrio	0366-3175	elsevier-with-titles	numeric
+Biosafety and Health	2590-0536	elsevier-with-titles	numeric
 Biomedical Signal Processing and Control	1746-8094	elsevier-with-titles	numeric
+Journal of Biotechnology: X	2590-1559	elsevier-harvard	author-date
 Journal of Behavior Therapy and Experimental Psychiatry	0005-7916	apa	author-date
 Biotechnology Reports	2215-017X	elsevier-with-titles	numeric
 Bulletin du Cancer	0007-4551	elsevier-vancouver	numeric
 Bulletin des sciences mathématiques	0007-4497	elsevier-with-titles	numeric
-Burnout Research	2213-0586	apa	author-date
+Burns Open	2468-9122	elsevier-vancouver	numeric
 Business Horizons	0007-6813	apa	author-date
 Computers and Chemical Engineering	0098-1354	elsevier-harvard	author-date
+City and Climate Interactions	2590-2520	elsevier-vancouver	numeric
 Computers & Education	0360-1315	apa	author-date
 Computers and Electrical Engineering	0045-7906	elsevier-vancouver	numeric
 Computers and Fluids	0045-7930	elsevier-vancouver	numeric
 Computers & Graphics	0097-8493	elsevier-vancouver	numeric
 Computers and Geosciences	0098-3004	elsevier-harvard	author-date
+Computers & Graphics: X	2590-1486	elsevier-vancouver	numeric
 Cahiers de la puéricultrice	0007-9820	elsevier-vancouver	numeric
 Computers & Industrial Engineering	0360-8352	apa	author-date
 Calphad	0364-5916	elsevier-with-titles	numeric
@@ -277,7 +269,7 @@ Computers and Mathematics with Applications	0898-1221	elsevier-with-titles	numer
 Cancer Letters	0304-3835	elsevier-with-titles	numeric
 Cancer Epidemiology	1877-7821	elsevier-with-titles	numeric
 Cancer / Radiothérapie	1278-3218	elsevier-vancouver	numeric
-Computers and Operations Research	0305-0548	elsevier-vancouver	numeric
+Computers and Operations Research	0305-0548	elsevier-harvard	author-date
 Current Applied Physics	1567-1739	elsevier-with-titles	numeric
 Carbohydrate Research	0008-6215	elsevier-with-titles	numeric
 Carbon	0008-6223	elsevier-with-titles	numeric
@@ -307,24 +299,23 @@ Chemical Data Collections	2405-8300	elsevier-with-titles	numeric
 Chronic Diseases and Translational Medicine	2095-882X	american-medical-association	numeric
 Cement and Concrete Composites	0958-9465	elsevier-with-titles	numeric
 Clinical Epidemiology and Global Health	2213-3984	american-medical-association	numeric
+Clinical eHealth	2588-9141	american-medical-association	numeric
 Chemical Engineering Journal	1385-8947	elsevier-with-titles	numeric
 Cell	0092-8674	elsevier-harvard	author-date
 Cell Reports	2211-1247	elsevier-harvard	author-date
 Cell Systems	2405-4712	elsevier-harvard	author-date
 Cement and Concrete Research	0008-8846	elsevier-with-titles	numeric
-Coastal Engineering	0378-3839	elsevier-with-titles	numeric
-Chemical Engineering & Processing: Process Intensification	0255-2701	elsevier-with-titles	numeric
+Coastal Engineering	0378-3839	elsevier-harvard	author-date
+Chemical Engineering and Processing - Process Intensification	0255-2701	elsevier-with-titles	numeric
 Ceramics International	0272-8842	elsevier-with-titles	numeric
-Cerevisia	1373-7163	elsevier-harvard	author-date
 Chemical Engineering Science	0009-2509	elsevier-harvard	author-date
-Cuadernos de Economía	0210-0266	elsevier-harvard	author-date
+Chemical Engineering Science: X	2590-1400	elsevier-harvard	author-date
 Computers, Environment and Urban Systems	0198-9715	apa	author-date
 Cancer Genetics	2210-7762	elsevier-vancouver	numeric
 Cytokine and Growth Factor Reviews	1359-6101	elsevier-with-titles	numeric
 Chaos, Solitons and Fractals: the interdisciplinary journal of Nonlinear Science, and Nonequilibrium and Complex Phenomena	0960-0779	elsevier-vancouver	numeric
 Computers in Human Behavior	0747-5632	apa	author-date
 Chemosphere	0045-6535	elsevier-harvard	author-date
-Chemie der Erde - Geochemistry - Interdisciplinary Journal for Chemical Problems of the Geosciences and Geoecology	0009-2819	elsevier-harvard	author-date
 Chemical Geology	0009-2541	elsevier-harvard	author-date
 Chemometrics and Intelligent Laboratory Systems	0169-7439	elsevier-with-titles	numeric
 Chemical Physics	0301-0104	elsevier-with-titles	numeric
@@ -333,6 +324,7 @@ Journal of Chemical Neuroanatomy	0891-0618	elsevier-harvard	author-date
 Chemical Engineering Research and Design	0263-8762	elsevier-harvard	author-date
 Child Abuse & Neglect	0145-2134	apa	author-date
 China Economic Review	1043-951X	apa	author-date
+Chinese Herbal Medicines	1674-6384	apa	author-date
 Acta Ecologica Sinica	1872-2032	elsevier-with-titles	numeric
 Cell Host & Microbe	1931-3128	elsevier-harvard	author-date
 Journal of Chromatography A	0021-9673	elsevier-with-titles	numeric
@@ -344,9 +336,10 @@ The Crop Journal	2214-5141	elsevier-with-titles	numeric
 China Journal of Accounting Research	1755-3091	elsevier-harvard	author-date
 Canadian Journal of Cardiology	0828-282X	american-medical-association	numeric
 Chinese Journal of Chemical Engineering	1004-9541	elsevier-with-titles	numeric
+CJC Open	2589-790X	elsevier-with-titles	numeric
 Chinese Journal of Physics	0577-9073	elsevier-with-titles	numeric
 Chinese Journal of Traumatology	1008-1275	american-medical-association	numeric
-Contact Lens and Anterior Eye	1367-0484	elsevier-with-titles	numeric
+Contact Lens and Anterior Eye	1367-0484	elsevier-vancouver	numeric
 Applied Clay Science	0169-1317	elsevier-harvard	author-date
 Clinical Biochemistry	0009-9120	elsevier-with-titles	numeric
 Clinical Breast Cancer	1526-8209	american-medical-association	numeric
@@ -354,17 +347,16 @@ Clinical Colorectal Cancer	1533-0028	american-medical-association	numeric
 Clinical Genitourinary Cancer	1558-7673	american-medical-association	numeric
 Clinical Neurology and Neurosurgery	0303-8467	elsevier-with-titles	numeric
 Clinical Mass Spectrometry	2376-9998	elsevier-with-titles	numeric
-Clinical Neurophysiology	1388-2457	elsevier-vancouver-author-date	author-date
+Clinical Neurophysiology	1388-2457	vancouver-author-date	author-date
 Clinics and Research in Hepatology and Gastroenterology	2210-7401	elsevier-vancouver	numeric
+Clinics and Research in Hepatology and Gastroenterology: X	2590-1443	elsevier-vancouver	numeric
 Climate Services	2405-8807	elsevier-harvard	author-date
 Clinical Therapeutics	0149-2918	american-medical-association	numeric
 Clinical Lung Cancer	1525-7304	american-medical-association	numeric
 Clinical Lymphoma, Myeloma and Leukemia	2152-2650	american-medical-association	numeric
 Clinical Nutrition ESPEN	2405-4577	elsevier-vancouver	numeric
 Cellular Signalling	0898-6568	elsevier-with-titles	numeric
-Clinical Skin Cancer	2405-8645	american-medical-association	numeric
-Computer Law & Security Review: The International Journal of Technology Law and Practice	0267-3649	elsevier-vancouver-author-date	author-date
-Clínica y Salud	1130-5274	apa	author-date
+Computer Law & Security Review: The International Journal of Technology Law and Practice	0267-3649	vancouver-author-date	author-date
 Computer Methods in Applied Mechanics and Engineering	0045-7825	elsevier-with-titles	numeric
 Cell Metabolism	1550-4131	elsevier-harvard	author-date
 Clinical Microbiology and Infection	1198-743X	elsevier-vancouver	numeric
@@ -372,22 +364,20 @@ Computerized Medical Imaging and Graphics	0895-6111	elsevier-harvard	author-date
 Clinical Microbiology Newsletter	0196-4399	elsevier-vancouver	numeric
 Current Medicine Research and Practice	2352-0817	american-medical-association	numeric
 Cahiers de Nutrition et de Diététique	0007-9960	elsevier-vancouver	numeric
+China Geology	2096-5192	elsevier-harvard	author-date
 Clinical Neurophysiology Practice	2467-981X	elsevier-harvard	author-date
-Chinese Nursing Research	2095-7718	american-medical-association	numeric
 Communications in Nonlinear Science and Numerical Simulation	1007-5704	elsevier-vancouver	numeric
 Current Opinion in Chemical Engineering	2211-3398	elsevier-with-titles	numeric
-Current Opinion in Colloid & Interface Science	1359-0294	elsevier-vancouver	numeric
 Composites Communications	2452-2139	elsevier-with-titles	numeric
 Computational Condensed Matter	2352-2143	elsevier-with-titles	numeric
 Computers and Composition	8755-4615	apa	author-date
-Current Opinion in Electrochemistry	2451-9103	elsevier-with-titles	numeric
-Clinical Ovarian and Other Gynecologic Cancer	2212-9553	american-medical-association	numeric
 Cognitive Development	0885-2014	apa	author-date
 Computers and Geotechnics	0266-352X	elsevier-vancouver	numeric
 International Journal of Coal Geology	0166-5162	elsevier-harvard	author-date
 Cognition	0010-0277	apa	author-date
 Current Opinion in Green and Sustainable Chemistry	2452-2236	elsevier-with-titles	numeric
 Cognitive Systems Research	1389-0417	apa	author-date
+Journal of Computer Languages	2590-1184	elsevier-with-titles	numeric
 Colloid and Interface Science Communications	2215-0382	elsevier-with-titles	numeric
 Collegian	1322-7696	apa	author-date
 Colloids and Surfaces A: Physicochemical and Engineering Aspects	0927-7757	elsevier-with-titles	numeric
@@ -413,26 +403,30 @@ Contemporary Clinical Trials	1551-7144	elsevier-with-titles	numeric
 Contemporary Clinical Trials Communications	2451-8654	elsevier-with-titles	numeric
 Journal of Contaminant Hydrology	0169-7722	elsevier-harvard	author-date
 Control Engineering Practice	0967-0661	apa	author-date
+Contraception: X	2590-1516	elsevier-vancouver	numeric
 Current Opinion in Psychology	2352-250X	elsevier-with-titles	numeric
 Journal of Controlled Release	0168-3659	elsevier-with-titles	numeric
 Journal of Corporate Finance	0929-1199	elsevier-harvard	author-date
 Cortex	0010-9452	apa	author-date
-Computers & Security	0167-4048	elsevier-vancouver-author-date	author-date
+Computers & Security	0167-4048	vancouver-author-date	author-date
 Computer Science Review	1574-0137	elsevier-with-titles	numeric
 Current Opinion in Solid State & Materials Science	1359-0286	elsevier-with-titles	numeric
 Composite Structures	0263-8223	elsevier-vancouver	numeric
-Current Opinion in Toxicology	2468-2020	elsevier-with-titles	numeric
 Current Plant Biology	2214-6628	elsevier-with-titles	numeric
 Chemistry and Physics of Lipids	0009-3084	elsevier-harvard	author-date
 Chemical Physics Letters	0009-2614	elsevier-with-titles	numeric
+Chemical Physics Letters: X	2590-1419	elsevier-with-titles	numeric
 Clinical Plasma Medicine	2212-8166	elsevier-with-titles	numeric
 Clinical Psychology Review	0272-7358	apa	author-date
 Currents in Pharmacy Teaching and Learning	1877-1297	american-medical-association	numeric
-Clinical Queries: Nephrology	2211-9477	american-medical-association	numeric
+Cell Regeneration	2045-9769	american-medical-association	numeric
 Comptes rendus - Geoscience	1631-0713	elsevier-harvard	author-date
 Comptes rendus - Mécanique	1631-0721	elsevier-with-titles	numeric
 Comptes rendus - Mathématique	1631-073X	elsevier-with-titles	numeric
 Comptes rendus - Biologies	1631-0691	elsevier-with-titles	numeric
+Current Research in Biotechnology	2590-2628	elsevier-harvard	author-date
+Current Research in Cell Biology	2590-2636	elsevier-harvard	author-date
+Carbon Resources Conversion	2588-9133	elsevier-with-titles	numeric
 Climate Risk Management	2212-0963	elsevier-harvard	author-date
 Cor et Vasa	0010-8650	elsevier-with-titles	numeric
 Case Reports in Women's Health	2214-9112	elsevier-with-titles	numeric
@@ -440,26 +434,22 @@ Journal of Crystal Growth	0022-0248	elsevier-with-titles	numeric
 Corrosion Science	0010-938X	elsevier-with-titles	numeric
 Computational and Structural Biotechnology Journal	2001-0370	elsevier-vancouver	numeric
 Case Studies in Construction Materials	2214-5095	elsevier-with-titles	numeric
-Case Studies in Engineering Failure Analysis	2213-2902	elsevier-vancouver	numeric
-Case Studies in Fire Safety	2214-398X	elsevier-with-titles	numeric
+Chaos, Solitons & Fractals: X	2590-0544	elsevier-vancouver	numeric
 Computer Standards & Interfaces	0920-5489	elsevier-with-titles	numeric
 Case Studies in Thermal Engineering	2214-157X	elsevier-with-titles	numeric
-Case Studies in Mechanical Systems and Signal Processing	2351-9886	elsevier-with-titles	numeric
-Case Studies in Nondestructive Testing and Evaluation	2214-6571	elsevier-vancouver	numeric
 Continental Shelf Research	0278-4343	elsevier-harvard	author-date
-Case Studies in Structural Engineering	2214-3998	elsevier-with-titles	numeric
 Composites Science and Technology	0266-3538	elsevier-with-titles	numeric
 Case Studies on Transport Policy	2213-624X	elsevier-harvard	author-date
 Cancer Treatment and Research Communications	2468-2942	elsevier-with-titles	numeric
 Complementary Therapies in Clinical Practice	1744-3881	elsevier-with-titles	numeric
 Clinical and Translational Radiation Oncology	2405-6308	elsevier-vancouver	numeric
-Clinical Trials and Regulatory Science in Cardiology	2405-5875	elsevier-with-titles	numeric
 Journal of Cultural Heritage	1296-2074	elsevier-with-titles	numeric
 Current Biology	0960-9822	elsevier-vancouver	numeric
 Current Therapeutic Research	0011-393X	american-medical-association	numeric
 Cardiovascular Pathology	1054-8807	elsevier-vancouver	numeric
 Contaduría y Administración	0186-1042	apa	author-date
 Children and Youth Services Review	0190-7409	apa	author-date
+Cytokine: X	2590-1532	elsevier-with-titles	numeric
 Digital Applications in Archaeology and Cultural Heritage	2212-0548	elsevier-harvard	author-date
 Drug and Alcohol Dependence	0376-8716	elsevier-harvard	author-date
 Alzheimer's & Dementia: Diagnosis, Assessment & Disease Monitoring	2352-8729	elsevier-vancouver	numeric
@@ -469,36 +459,31 @@ Data & Knowledge Engineering	0169-023X	elsevier-with-titles	numeric
 Digital Communications and Networks	2352-8648	elsevier-with-titles	numeric
 Developmental and Comparative Immunology	0145-305X	elsevier-harvard	author-date
 Discourse, Context & Media	2211-6958	elsevier-harvard	author-date
+Digital Chinese Medicine	2589-3777	elsevier-with-titles	numeric
 Developmental Cognitive Neuroscience	1878-9293	elsevier-harvard	author-date
-Drug Discovery Today: Disease Mechanisms	1740-6765	elsevier-vancouver	numeric
 Drug Discovery Today: Disease Models	1740-6757	elsevier-vancouver	numeric
-Drug Discovery Today: Therapeutic Strategies	1740-6773	elsevier-vancouver	numeric
 Drug Discovery Today: Technologies	1740-6749	elsevier-vancouver	numeric
 Decision Support Systems	0167-9236	elsevier-with-titles	numeric
 Dendrochronologia	1125-7865	elsevier-harvard	author-date
 Dental Materials	0109-5641	elsevier-vancouver	numeric
 Desalination	0011-9164	elsevier-with-titles	numeric
 Journal of Dermatological Science	0923-1811	elsevier-with-titles	numeric
-Journal of Dermatological Science Supplement	1574-0757	elsevier-vancouver	numeric
 Developmental Cell	1534-5807	elsevier-harvard	author-date
 Journal of Development Economics	0304-3878	elsevier-harvard	author-date
 Development Engineering	2352-7285	elsevier-harvard	author-date
-Debate Feminista	0188-9478	apa	author-date
 Disability and Health Journal	1936-6574	american-medical-association	numeric
 Diabetes Research and Clinical Practice	0168-8227	elsevier-vancouver	numeric
-Diabetes and Metabolism	1262-3636	elsevier-vancouver	numeric
+Diabetes & Metabolism	1262-3636	elsevier-vancouver	numeric
+Diabetes & Metabolism: X	2590-1540	elsevier-vancouver	numeric
 Diamond & Related Materials	0925-9635	elsevier-with-titles	numeric
 Data in Brief	2352-3409	elsevier-with-titles	numeric
 Differentiation	0301-4681	elsevier-harvard	author-date
 Differential Geometry and its Applications	0926-2245	elsevier-with-titles	numeric
 Diagnostic and Interventional Imaging	2211-5684	elsevier-vancouver	numeric
-Digital Investigation	1742-2876	elsevier-vancouver-author-date	author-date
-Diagnostics in Neuropsychiatry	2405-8017	american-medical-association	numeric
+Digital Investigation	1742-2876	elsevier-harvard	author-date
 Discrete Optimization	1572-5286	elsevier-with-titles	numeric
 Displays	0141-9382	elsevier-with-titles	numeric
-Drug Invention Today	0975-7619	american-medical-association	numeric
-Digestive and Liver Disease Supplements	1594-5804	elsevier-vancouver	numeric
-Diagnostic Microbiology & Infectious Disease	0732-8893	elsevier-vancouver-author-date	author-date
+Diagnostic Microbiology & Infectious Disease	0732-8893	vancouver-author-date	author-date
 Drug Metabolism and Pharmacokinetics	1347-4367	elsevier-vancouver	numeric
 International Journal of Developmental Neuroscience	0736-5748	elsevier-harvard	author-date
 DNA Repair	1568-7864	elsevier-with-titles	numeric
@@ -520,11 +505,13 @@ Early Childhood Research Quarterly	0885-2006	apa	author-date
 Earth-Science Reviews	0012-8252	elsevier-harvard	author-date
 Eating Behaviors	1471-0153	apa	author-date
 Epilepsy & Behavior Case Reports	2213-3232	elsevier-vancouver	numeric
-EBioMedicine	2352-3964	elsevier-harvard	author-date
+EBioMedicine	2352-3964	elsevier-vancouver	numeric
 Education for Chemical Engineers	1749-7728	elsevier-harvard	author-date
 Journal of Chiropractic Humanities	1556-3499	american-medical-association	numeric
+EClinicalMedicine	2589-5370	elsevier-vancouver	numeric
 Energy Conversion and Management	0196-8904	elsevier-vancouver	numeric
 Economic Modelling	0264-9993	elsevier-harvard	author-date
+Energy Conversion and Management: X	2590-1745	elsevier-vancouver	numeric
 Ecological Complexity	1476-945X	elsevier-harvard	author-date
 Economics of Education Review	0272-7757	apa	author-date
 Ecological Engineering	0925-8574	elsevier-harvard	author-date
@@ -554,8 +541,7 @@ Energy	0360-5442	elsevier-vancouver	numeric
 Energy Reports	2352-4847	elsevier-harvard	author-date
 Economics and Human Biology	1570-677X	elsevier-harvard	author-date
 Early Human Development	0378-3782	elsevier-with-titles	numeric
-Estudios de Historia Moderna y Contemporánea de México	0185-2620	apa	author-date
-Estudios de Historia Novohispana	1870-9060	apa	author-date
+The Egyptian Heart Journal	1110-2608	american-medical-association	numeric
 Human Pathology: Case Reports	2214-3300	elsevier-with-titles	numeric
 Environment International	0160-4120	elsevier-harvard	author-date
 Egyptian Informatics Journal	1110-8665	elsevier-vancouver	numeric
@@ -567,11 +553,7 @@ Electronic Journal of Biotechnology	0717-3458	elsevier-vancouver	numeric
 European Journal of Cancer	0959-8049	elsevier-vancouver	numeric
 European Journal of Cell Biology	0171-9335	elsevier-harvard	author-date
 The Egyptian Journal of Critical Care Medicine	2090-7303	elsevier-vancouver	numeric
-Egyptian Journal of Chest Diseases and Tuberculosis	0422-7638	elsevier-with-titles	numeric
 EJC Supplements	1359-6349	elsevier-vancouver	numeric
-Egyptian Journal of Ear, Nose, Throat and Allied Sciences	2090-0740	american-medical-association	numeric
-European Journal of Education and Psychology	1888-8992	apa	author-date
-European Journal of Family Business	2444-877X	apa	author-date
 European Journal of Internal Medicine	0953-6205	elsevier-vancouver	numeric
 European Journal of Medicinal Chemistry	0223-5234	elsevier-with-titles	numeric
 European Journal of Mechanics / B Fluids	0997-7546	elsevier-with-titles	numeric
@@ -581,14 +563,15 @@ Physica Medica	1120-1797	elsevier-vancouver	numeric
 European Journal of Mechanics / A Solids	0997-7538	elsevier-harvard	author-date
 European Journal of Protistology	0932-4739	elsevier-harvard	author-date
 European Journal of Pharmacology	0014-2999	elsevier-harvard	author-date
-The European Journal of Psychology Applied to Legal Context	1889-1861	apa	author-date
 European Journal of Pharmaceutics and Biopharmaceutics	0939-6411	elsevier-with-titles	numeric
+Egyptian Journal of Petroleum	1110-0621	elsevier-with-titles	numeric
 The Egyptian Rheumatologist	1110-1164	elsevier-vancouver	numeric
 Journal of Hydrology: Regional Studies	2214-5818	elsevier-harvard	author-date
 The Egyptian Journal of Radiology and Nuclear Medicine	0378-603X	elsevier-vancouver	numeric
 European Journal of Radiology Open	2352-0477	elsevier-with-titles	numeric
 The Egyptian Journal of Remote Sensing and Space Sciences	1110-9823	elsevier-harvard	author-date
 European Journal of Soil Biology	1164-5563	elsevier-with-titles	numeric
+European Journal of Trauma & Dissociation	2468-7499	apa	author-date
 Journal of the World Federation of Orthodontists	2212-4438	elsevier-vancouver	numeric
 Electrochemistry Communications	1388-2481	elsevier-with-titles	numeric
 The Electricity Journal	1040-6190	elsevier-harvard	author-date
@@ -621,43 +604,39 @@ Environmental Development	2211-4645	elsevier-harvard	author-date
 Environmental Science and Policy	1462-9011	elsevier-harvard	author-date
 Environmental Toxicology and Pharmacology	1382-6689	elsevier-harvard	author-date
 European Journal of Operational Research	0377-2217	apa	author-date
-Earth-Observations-X	2468-1199	elsevier-harvard	author-date
-Pediatric Dentistry Case Reports	2352-5894	american-medical-association	numeric
+Egyptian Pediatric Association Gazette	1110-6638	american-medical-association	numeric
 Epidemics	1755-4365	elsevier-harvard	author-date
-Epileptology	2212-8220	elsevier-vancouver-author-date	author-date
 Epilepsy Research	0920-1211	elsevier-harvard	author-date
 European Polymer Journal	0014-3057	elsevier-with-titles	numeric
 Evaluation and Program Planning	0149-7189	apa	author-date
 Journal of Pediatric Surgery Case Reports	2213-5766	elsevier-vancouver	numeric
 Earth and Planetary Science Letters	0012-821X	elsevier-harvard	author-date
 Electric Power Systems Research	0378-7796	elsevier-with-titles	numeric
-Educación Química	0187-893X	apa	author-date
 Revue européenne de psychologie appliquée	1162-9088	apa	author-date
 International Journal of Industrial Ergonomics	0169-8141	elsevier-harvard	author-date
 Energy Research & Social Science	2214-6296	elsevier-with-titles	numeric
-Energy for Sustainable Development	0973-0826	elsevier-vancouver-author-date	author-date
-Ensayos sobre Política Económica	0120-4483	apa	author-date
+Energy for Sustainable Development	0973-0826	apa	author-date
+Earth System Governance	2589-8116	elsevier-harvard	author-date
 Energy Strategy Reviews	2211-467X	elsevier-with-titles	numeric
 Journal of Energy Storage	2352-152X	elsevier-with-titles	numeric
-Estudios Gerenciales	0123-5923	apa	author-date
 Expert Systems With Applications	0957-4174	apa	author-date
 Sexual Medicine	2050-1161	elsevier-vancouver	numeric
 Experimental Thermal and Fluid Science	0894-1777	elsevier-with-titles	numeric
 Environmental Technology & Innovation	2352-1864	elsevier-harvard	author-date
 Ethique et Santé	1765-4629	elsevier-vancouver	numeric
 Experimental and Toxicologic Pathology	0940-2993	elsevier-harvard	author-date
+eTransportation	2590-1168	elsevier-harvard	author-date
 Urology Case Reports	2214-4420	american-medical-association	numeric
 European Urology Focus	2405-4569	elsevier-vancouver	numeric
 European Journal of Integrative Medicine	1876-3820	elsevier-with-titles	numeric
+European Urology Oncology	2588-9311	elsevier-vancouver	numeric
 EuPA Open Proteomics	2212-9685	elsevier-with-titles	numeric
 European Journal of Agronomy	1161-0301	elsevier-harvard	author-date
-Journal of Eurasian Studies	1879-3665	apa	author-date
-European Geriatric Medicine	1878-7649	elsevier-vancouver	numeric
-European Journal of Obstetrics and Gynecology	0301-2115	elsevier-vancouver	numeric
+European Journal of Obstetrics & Gynecology and Reproductive Biology	0301-2115	elsevier-vancouver	numeric
+European Journal of Obstetrics & Gynecology and Reproductive Biology: X	2590-1613	elsevier-vancouver	numeric
 European Psychiatry	0924-9338	elsevier-vancouver	numeric
 European Journal of Radiology	0720-048X	elsevier-with-titles	numeric
 European Urology Supplements	1569-9056	elsevier-vancouver	numeric
-European Research in Telemedicine/La Recherche Européenne en Télémédecine	2212-764X	elsevier-vancouver	numeric
 European Urology	0302-2838	elsevier-vancouver	numeric
 L'Évolution psychiatrique	0014-3855	elsevier-vancouver	numeric
 Experimental Gerontology	0531-5565	elsevier-harvard	author-date
@@ -673,24 +652,23 @@ Food and Chemical Toxicology	0278-6915	elsevier-harvard	author-date
 Future Dental Journal	2314-7180	elsevier-vancouver	numeric
 Imagerie de la Femme	1776-9817	elsevier-vancouver	numeric
 Journal of the Franklin Institute	0016-0032	elsevier-with-titles	numeric
-Fuzzy Information and Engineering	1616-8658	elsevier-with-titles	numeric
 Field Crops Research	0378-4290	elsevier-harvard	author-date
 International Review of Financial Analysis	1057-5219	apa	author-date
-Procedia Economics and Finance	2212-5671	elsevier-harvard	author-date
 Journal of Financial Economics	0304-405X	elsevier-harvard	author-date
 Finite Elements in Analysis & Design	0168-874X	elsevier-with-titles	numeric
 Journal of Financial Markets	1386-4181	elsevier-harvard	author-date
 Fisheries Research	0165-7836	elsevier-harvard	author-date
 Fire Safety Journal	0379-7112	elsevier-with-titles	numeric
 Fitoterapia	0367-326X	elsevier-with-titles	numeric
-Future Journal of Pharmaceutical sciences	2314-7245	american-medical-association	numeric
-Formosan Journal of Surgery	1682-606X	american-medical-association	numeric
+Future Journal of Pharmaceutical sciences	2314-7245	elsevier-with-titles	numeric
 FlatChem	2452-2627	elsevier-with-titles	numeric
+Frontiers in Laboratory Medicine	2542-3649	american-medical-association	numeric
 Flora	0367-2530	elsevier-harvard	author-date
 Fluid Phase Equilibria	0378-3812	elsevier-with-titles	numeric
 Journal of Fluorine Chemistry	0022-1139	elsevier-with-titles	numeric
 Frontiers of Architectural Research	2095-2635	elsevier-harvard	author-date
 Food Chemistry	0308-8146	apa	author-date
+Food Chemistry: X	2590-1575	apa	author-date
 International Journal of Food Microbiology	0168-1605	elsevier-harvard	author-date
 Food Hydrocolloids	0268-005X	apa	author-date
 Food Structure	2213-3291	apa	author-date
@@ -701,8 +679,6 @@ Forest Policy and Economics	1389-9341	elsevier-harvard	author-date
 Food Packaging and Shelf Life	2214-2894	apa	author-date
 Progrès en Urologie - FMC	1761-676X	elsevier-vancouver	numeric
 Food Quality and Preference	0950-3293	apa	author-date
-Free Radicals and Antioxidants	2231-2536	american-medical-association	numeric
-Feuillets de Radiologie	0181-9801	elsevier-vancouver	numeric
 Free Radical Biology and Medicine	0891-5849	elsevier-with-titles	numeric
 Food Research International	0963-9969	apa	author-date
 Finance Research Letters	1544-6123	elsevier-harvard	author-date
@@ -711,29 +687,29 @@ Forensic Science International	0379-0738	elsevier-with-titles	numeric
 Forensic Science International: Genetics	1872-4973	elsevier-with-titles	numeric
 Forensic Science International: Genetics Supplement Series	1875-1768	elsevier-with-titles	numeric
 Forensic Science International Supplement Series	1875-1741	elsevier-with-titles	numeric
+Forensic Science International: Synergy	2589-871X	elsevier-with-titles	numeric
 Fuzzy Sets and Systems	0165-0114	elsevier-with-titles	numeric
-Fisterra	2444-9164	elsevier-vancouver-author-date	author-date
+Fungal Biology	1878-6146	elsevier-harvard	author-date
 Fungal Ecology	1754-5048	elsevier-harvard	author-date
 Fuel Processing Technology	0378-3820	elsevier-with-titles	numeric
 Fusion Engineering and Design	0920-3796	elsevier-with-titles	numeric
 Fuss und Sprunggelenk	1619-9987	elsevier-vancouver	numeric
 Future Generation Computer Systems	0167-739X	elsevier-with-titles	numeric
 Gait & Posture	0966-6362	elsevier-with-titles	numeric
-Genomics Data	2213-5960	elsevier-with-titles	numeric
 Global Ecology and Conservation	2351-9894	elsevier-harvard	author-date
 Green Energy & Environment	2468-0257	elsevier-without-titles	numeric
 Geotextiles and Geomembranes	0266-1144	elsevier-harvard	author-date
-Global Economics and Management Review	2340-1540	apa	author-date
 Genes & Diseases	2352-3042	american-medical-association	numeric
 Gene	0378-1119	elsevier-harvard	author-date
-Gender Medicine	1550-8579	american-medical-association	numeric
+Gene: X	2590-1583	elsevier-harvard	author-date
 Gene Reports	2452-0144	elsevier-harvard	author-date
 Geobios	0016-6995	elsevier-harvard	author-date
+Geochemistry	1611-5864	elsevier-harvard	author-date
 Journal of Geodynamics	0264-3707	elsevier-harvard	author-date
 Geoderma	0016-7061	elsevier-harvard	author-date
 Geoderma Regional	2352-0094	elsevier-harvard	author-date
 Geoforum	0016-7185	elsevier-harvard	author-date
-Geodesy and Geodynamics	1674-9847	elsevier-vancouver	numeric
+Geodesy and Geodynamics	1674-9847	elsevier-with-titles	numeric
 Geomorphology	0169-555X	elsevier-harvard	author-date
 Journal of Geometry and Physics	0393-0440	elsevier-with-titles	numeric
 Geothermics	0375-6505	elsevier-harvard	author-date
@@ -743,37 +719,34 @@ Global Food Security	2211-9124	elsevier-harvard	author-date
 Global Heart	2211-8160	elsevier-vancouver	numeric
 General Hospital Psychiatry	0163-8343	elsevier-vancouver	numeric
 Global and Planetary Change	0921-8181	elsevier-harvard	author-date
+Global Energy Interconnection	2096-5117	elsevier-with-titles	numeric
 Global Finance Journal	1044-0283	apa	author-date
-Geriatric Mental Health Care	2212-9693	elsevier-harvard	author-date
-Gynecology and Minimally Invasive Therapy	2213-3070	american-medical-association	numeric
+Global Transitions	2589-7918	elsevier-with-titles	numeric
+Gynécologie Obstétrique Fertilité & Sénologie	2468-7189	elsevier-vancouver	numeric
 Gynecologic Oncology Reports	2352-5789	elsevier-harvard	author-date
 Government Information Quarterly	0740-624X	apa	author-date
 Genomics, Proteomics & Bioinformatics	1672-0229	elsevier-vancouver	numeric
 Gondwana Research	1342-937X	elsevier-harvard	author-date
-GeoResJ	2214-2428	elsevier-vancouver	numeric
 Groundwater for Sustainable Development	2352-801X	elsevier-harvard	author-date
-Gynécologie Obstétrique et Fertilité	1297-9589	elsevier-vancouver	numeric
 Habitat International	0197-3975	apa	author-date
 Hand Surgery and Rehabilitation	2468-1229	elsevier-vancouver	numeric
 Journal of Hand Therapy	0894-1130	american-medical-association	numeric
 Harmful Algae	1568-9883	elsevier-harvard	author-date
 Journal of Hazardous Materials	0304-3894	elsevier-with-titles	numeric
+Hepatobiliary & Pancreatic Diseases International	1499-3872	elsevier-vancouver	numeric
 HBRC Journal	1687-4048	elsevier-with-titles	numeric
-Healthcare Management Forum	0840-4704	american-medical-association	numeric
 International Journal of Hydrogen Energy	0360-3199	elsevier-vancouver	numeric
 Health policy	0168-8510	elsevier-vancouver	numeric
 Hearing Research	0378-5955	elsevier-harvard	author-date
 High Energy Density Physics	1574-1818	elsevier-with-titles	numeric
 Hematology/Oncology and Stem Cell Therapy	1658-3876	elsevier-vancouver	numeric
 Journal of Herbal Medicine	2210-8033	elsevier-harvard	author-date
+Hemorrhagic Stroke	2589-238X	american-medical-association	numeric
 International Journal of Heat and Fluid Flow	0142-727X	elsevier-harvard	author-date
 Journal of High Technology Management Research	1047-8310	apa	author-date
 Human Immunology	0198-8859	elsevier-with-titles	numeric
-HIV & AIDS Review	1730-1270	elsevier-with-titles	numeric
 Hellenic Journal of Cardiology	1109-9666	american-medical-association	numeric
 Healthcare	2213-0764	american-medical-association	numeric
-Hong Kong Journal of Occupational Therapy	1569-1861	apa	author-date
-Hong Kong Physiotherapy Journal	1013-7025	elsevier-vancouver	numeric
 Heart, Lung and Circulation	1443-9506	elsevier-vancouver	numeric
 Health Policy and Technology	2211-8837	elsevier-vancouver	numeric
 Heliyon	2405-8440	elsevier-with-titles	numeric
@@ -782,11 +755,12 @@ International Journal of Heat and Mass Transfer	0017-9310	elsevier-with-titles	n
 Scientia Horticulturae	0304-4238	elsevier-harvard	author-date
 Health Professions Education	2452-3011	american-medical-association	numeric
 Horticultural Plant Journal	2468-0141	elsevier-harvard	author-date
-Health SA Gesondheid	1025-9848	apa	author-date
 Human Microbiome Journal	2452-2317	elsevier-vancouver	numeric
 Human Movement Science	0167-9457	apa	author-date
 Human Resource Management Review	1053-4822	apa	author-date
 Hormigón y Acero	0439-5689	elsevier-with-titles	numeric
+HydroResearch	2589-7578	elsevier-harvard	author-date
+Journal of Hydrology X	2589-9155	elsevier-harvard	author-date
 Journal of Hydrology	0022-1694	elsevier-harvard	author-date
 Hydrometallurgy	0304-386X	elsevier-harvard	author-date
 IATSS Research	0386-1112	elsevier-with-titles	numeric
@@ -795,7 +769,6 @@ International Business Review	0969-5931	apa	author-date
 IBRO Reports	2451-8301	elsevier-harvard	author-date
 Inorganica Chimica Acta	0020-1693	elsevier-with-titles	numeric
 International Communications in Heat and Mass Transfer	0735-1933	elsevier-with-titles	numeric
-International Comparative Jurisprudence	2351-6674	apa	author-date
 ICT Express	2405-9595	elsevier-with-titles	numeric
 IDCases	2214-2509	elsevier-vancouver	numeric
 Infection, Disease & Health	2468-0451	elsevier-vancouver	numeric
@@ -804,45 +777,38 @@ International Journal of Impact Engineering	0734-743X	elsevier-vancouver	numeric
 European research on management and business economics	2444-8834	apa	author-date
 International Emergency Nursing	1755-599X	elsevier-vancouver	numeric
 Information Economics and Policy	0167-6245	elsevier-harvard	author-date
-IERI Procedia	2212-6678	elsevier-with-titles	numeric
-Investigaciones de Historia Económica - Economic History Research	1698-6989	elsevier-harvard	author-date
+IFAC Journal of Systems and Control	2468-6018	apa	author-date
+Investigaciones de Historia Económica	1698-6989	elsevier-harvard	author-date
 Indian Heart Journal	0019-4832	american-medical-association	numeric
+IHJ Cardiovascular Case Reports (CVCR)	2468-600X	american-medical-association	numeric
 IIMB Management Review	0970-3896	apa	author-date
 International Journal of Approximate Reasoning	0888-613X	elsevier-with-titles	numeric
 International Journal of Africa Nursing Sciences	2214-1391	apa	author-date
-International Journal of Adipose Tissue and Stem Cells	2211-9116	elsevier-vancouver	numeric
 International Journal of Medical Informatics	1386-5056	elsevier-with-titles	numeric
 International Journal of Cardiology	0167-5273	elsevier-with-titles	numeric
-International Journal of the Cardiovascular Academy	2405-8181	american-medical-association	numeric
-International Journal of Chemical and Analytical Science	0976-1209	american-medical-association	numeric
 International Journal of Child-Computer Interaction	2212-8689	elsevier-with-titles	numeric
 IJC Heart & Vasculature	2352-9067	elsevier-with-titles	numeric
 International Journal of Clinical and Health Psychology	1697-2600	apa	author-date
-IJC Metabolic & Endocrine	2214-7624	elsevier-with-titles	numeric
-Indian Journal of Dentistry	0975-962X	american-medical-association	numeric
-International Journal of Diabetes Mellitus	1877-5934	elsevier-vancouver	numeric
+International Journal of Cardiology Hypertension	2590-0862	elsevier-with-titles	numeric
 International Journal of Disaster Risk Reduction	2212-4209	elsevier-with-titles	numeric
-International Journal of Dental Science and Research	2213-9974	american-medical-association	numeric
-International Journal of Epilepsy	2213-6320	american-medical-association	numeric
 International Journal of Engineering Science	0020-7225	apa	author-date
-International Journal of Gynecology and Obstetrics	0020-7292	elsevier-vancouver	numeric
 International Journal of Gerontology	1873-9598	american-medical-association	numeric
 International Journal of Gastronomy and Food Science	1878-450X	elsevier-harvard	author-date
 International Journal of Greenhouse Gas Control	1750-5836	elsevier-harvard	author-date
 International Journal of Hygiene and Environmental Health	1438-4639	elsevier-harvard	author-date
+International Journal of Infectious Diseases	1201-9712	vancouver-author-date	author-date
 International Journal of Intercultural Relations	0147-1767	apa	author-date
+International Journal of Innovation Studies	2096-2487	apa	author-date
 International Journal of Law, Crime and Justice	1756-0616	elsevier-harvard	author-date
-Optik - International Journal for Light and Electron Optics	0030-4026	elsevier-with-titles	numeric
+Optik	0030-4026	elsevier-with-titles	numeric
+International Journal of Lightweight Materials and Manufacture	2588-8404	elsevier-with-titles	numeric
 International Journal of Law and Psychiatry	0160-2527	apa	author-date
 The International Journal of Management Education	1472-8117	apa	author-date
 International Journal of Multiphase Flow	0301-9322	elsevier-harvard	author-date
 International Journal of Medical Microbiology	1438-4221	elsevier-harvard	author-date
 International Journal of Mining Science and Technology	2095-2686	elsevier-vancouver	numeric
-International Journal of Mycobacteriology	2212-5531	elsevier-with-titles	numeric
 International Journal of Naval Architecture and Ocean Engineering	2092-6782	elsevier-harvard	author-date
 International Journal of Nursing Sciences	2352-0132	elsevier-vancouver	numeric
-The Indian Journal of Neurotrauma	0973-0508	american-medical-association	numeric
-International Journal of Marine Energy	2214-1669	elsevier-with-titles	numeric
 International Journal of Osteopathic Medicine	1746-0689	elsevier-vancouver	numeric
 International Journal of Orthopaedic and Trauma Nursing	1878-1241	elsevier-harvard	author-date
 International Journal of Pharmaceutics	0378-5173	elsevier-harvard	author-date
@@ -851,28 +817,26 @@ International Journal for Parasitology: Drugs and Drug Resistance	2211-3207	else
 International Journal of Paleopathology	1879-9817	elsevier-harvard	author-date
 International Journal for Parasitology: Parasites and Wildlife	2213-2244	elsevier-harvard	author-date
 International Journal of Pavement Research and Technology	1996-6814	elsevier-with-titles	numeric
+International Journal of Pharmaceutics: X	2590-1567	elsevier-harvard	author-date
 International Journal of Research in Marketing	0167-8116	apa	author-date
-International Journal of Sustainable Built Environment	2212-6090	elsevier-harvard	author-date
 International Journal of Surgery Case Reports	2210-2612	elsevier-with-titles	numeric
 International Journal of Surgery Open	2405-8572	elsevier-vancouver	numeric
 International Journal of Sediment Research	1001-6279	apa	author-date
 International Journal of Surgery	1743-9191	elsevier-with-titles	numeric
-Indian Journal of Transplantation	2212-0017	american-medical-association	numeric
 Indian Journal of Tuberculosis	0019-5707	american-medical-association	numeric
 International Journal of Transportation Science and Technology	2046-0430	elsevier-harvard	author-date
 International Journal of Veterinary Science and Medicine	2314-4599	elsevier-vancouver	numeric
-International Journal of Women's Dermatology	2352-6475	elsevier-vancouver-author-date	author-date
+International Journal of Women's Dermatology	2352-6475	vancouver-author-date	author-date
 Signal Processing: Image Communication	0923-5965	elsevier-with-titles	numeric
 Image and Vision Computing	0262-8856	elsevier-with-titles	numeric
 Immunobiology	0171-2985	elsevier-harvard	author-date
-Journal of Marine and Island Cultures	2212-6821	elsevier-harvard	author-date
 Immunology Letters	0165-2478	elsevier-with-titles	numeric
 Industrial Marketing Management	0019-8501	apa	author-date
-Immuno-analyse et biologie spécialisée	0923-2532	elsevier-vancouver	numeric
 Immunity	1074-7613	elsevier-harvard	author-date
 NanoImpact	2452-0748	elsevier-harvard	author-date
 Integrative Medicine Research	2213-4220	american-medical-association	numeric
 Informatics in Medicine Unlocked	2352-9148	elsevier-vancouver	numeric
+In Analysis	2542-3606	apa	author-date
 Interdisciplinary Neurosurgery: Advanced Techniques and Case Management	2214-7519	elsevier-with-titles	numeric
 International Biodeterioration & Biodegradation	0964-8305	elsevier-harvard	author-date
 International Dairy Journal	0958-6946	apa	author-date
@@ -880,23 +844,20 @@ Journal of Wind Engineering & Industrial Aerodynamics	0167-6105	elsevier-harvard
 Industrial Crops & Products	0926-6690	elsevier-harvard	author-date
 International Journal of Industrial Organization	0167-7187	elsevier-harvard	author-date
 Journal of International Economics	0022-1996	elsevier-harvard	author-date
-Injury Extra	1572-3461	elsevier-vancouver	numeric
 Infant Behavior and Development	0163-6383	apa	author-date
 Information Fusion	1566-2535	elsevier-with-titles	numeric
 Information & Management	0378-7206	elsevier-with-titles	numeric
 Information and Organization	1471-7727	apa	author-date
 Infrared Physics and Technology	1350-4495	elsevier-with-titles	numeric
+Infection Prevention in Practice	2590-0889	elsevier-vancouver	numeric
 Information and Software Technology	0950-5849	elsevier-with-titles	numeric
 Indian Journal of Medical Specialities	0976-2884	elsevier-vancouver	numeric
-Indian Journal of Rheumatology	0973-3698	american-medical-association	numeric
 Innovative Food Science and Emerging Technologies	1466-8564	apa	author-date
 Inorganic Chemistry Communications	1387-7003	elsevier-with-titles	numeric
 Information Processing in Agriculture	2214-3173	elsevier-vancouver	numeric
 Information Sciences	0020-0255	elsevier-with-titles	numeric
 Insurance Mathematics and Economics	0167-6687	elsevier-harvard	author-date
-Interacting with Computers	0953-5438	elsevier-harvard	author-date
 International Economics	2110-7017	elsevier-harvard	author-date
-Intellectual Economics	1822-8011	apa	author-date
 Intelligence	0160-2896	apa	author-date
 Journal of International Financial Markets, Institutions & Money	1042-4431	elsevier-harvard	author-date
 International Journal of Forecasting	0169-2070	apa	author-date
@@ -906,6 +867,8 @@ Journal of International Management	1075-4253	elsevier-harvard	author-date
 International Journal of Plasticity	0749-6419	elsevier-harvard	author-date
 International Journal of Psychophysiology	0167-8760	elsevier-harvard	author-date
 Internet Interventions	2214-7829	elsevier-harvard	author-date
+Internet of Things	2542-6605	elsevier-with-titles	numeric
+Immuno-Oncology Technology	2590-0188	elsevier-vancouver	numeric
 Journal of Insect Physiology	0022-1910	elsevier-harvard	author-date
 Indian Pacing and Electrophysiology Journal	0972-6292	elsevier-vancouver	numeric
 Information Processing Letters	0020-0190	elsevier-with-titles	numeric
@@ -917,28 +880,27 @@ International Review of Economics Education	1477-3880	elsevier-harvard	author-da
 International Review of Law & Economics	0144-8188	elsevier-harvard	author-date
 Information Systems	0306-4379	elsevier-with-titles	numeric
 ISA Transactions	0019-0578	elsevier-vancouver	numeric
+iScience	2589-0042	elsevier-harvard	author-date
 International Journal of Surgery Protocols	2468-3574	elsevier-with-titles	numeric
-International Strategic Management Review	2306-7748	apa	author-date
 Structures	2352-0124	elsevier-vancouver	numeric
 International Soil and Water Conservation Research	2095-6339	apa	author-date
 International Journal of Adhesion and Adhesives	0143-7496	elsevier-vancouver	numeric
 Journal of Analytical and Applied Pyrolysis	0165-2370	elsevier-with-titles	numeric
 Journal of Applied Biomedicine	1214-021X	elsevier-harvard	author-date
 Journal of Clinical Lipidology	1933-2874	american-medical-association	numeric
-Journal of Acute Medicine	2211-5587	american-medical-association	numeric
 Journal of the American College of Radiology	1546-1440	elsevier-vancouver	numeric
 Journal of Affective Disorders	0165-0327	elsevier-harvard	author-date
 Journal of Accounting and Economics	0165-4101	elsevier-harvard	author-date
 Journal of Asian Earth Sciences	1367-9120	elsevier-harvard	author-date
+Journal of Asian Earth Sciences: X	2590-0560	elsevier-harvard	author-date
 International Journal of Applied Earth Observations and Geoinformation	0303-2434	elsevier-harvard	author-date
 Journal of Adolescent Health	1054-139X	elsevier-vancouver	numeric
-Annals of the ICRP	0146-6453	elsevier-harvard	author-date
 Journal of Ayurveda and Integrative Medicine	0975-9476	elsevier-vancouver	numeric
 Journal of Arthroscopy and Joint Surgery	2214-9635	american-medical-association	numeric
-Journal of Applied Logic	1570-8683	elsevier-with-titles	numeric
 Journal of Alloys and Compounds	0925-8388	elsevier-with-titles	numeric
 Alzheimer's & Dementia: The Journal of the Alzheimer's Association	1552-5260	elsevier-vancouver	numeric
 Journal of the Academy of Nutrition and Dietetics	2212-2672	american-medical-association	numeric
+International Journal of Advanced Nuclear Reactor Design and Technology	2468-6050	elsevier-with-titles	numeric
 Journal of Anesthesia History	2352-4529	american-medical-association	numeric
 Applied Geography	0143-6228	apa	author-date
 Journal of the American Pharmacists Association	1544-3191	american-medical-association	numeric
@@ -947,14 +909,12 @@ Annual Reviews in Control	1367-5788	apa	author-date
 Journal of Advanced Research	2090-1232	elsevier-vancouver	numeric
 Journal of Applied Research in Memory and Cognition	2211-3681	apa	author-date
 Journal of Applied Research on Medicinal and Aromatic Plants	2214-7861	elsevier-harvard	author-date
-Journal of Applied Research and Technology	1665-6423	apa	author-date
 Journal of the American Society of Cytopathology	2213-2945	american-medical-association	numeric
 Journal of the Anatomical Society of India	0003-2778	american-medical-association	numeric
 Advances in Space Research	0273-1177	elsevier-harvard	author-date
 Journal of Archaeological Science: Reports	2352-409X	elsevier-harvard	author-date
 Journal of African Trade	2214-8515	elsevier-harvard	author-date
 Journal of Air Transport Management	0969-6997	elsevier-harvard	author-date
-Journal of the Association of Arab Universities for Basic and Applied Sciences	1815-3852	elsevier-harvard	author-date
 Journal of the Association for Vascular Access	1552-8855	american-medical-association	numeric
 Biotechnology Advances	0734-9750	elsevier-harvard	author-date
 Biomass and Bioenergy	0961-9534	elsevier-with-titles	numeric
@@ -974,15 +934,14 @@ Journal of Contemporary Accounting & Economics	1815-5669	elsevier-harvard	author
 Construction and Building Materials	0950-0618	elsevier-with-titles	numeric
 Journal of Contextual Behavioral Science	2212-1447	apa	author-date
 Journal of Cardiology Cases	1878-5409	elsevier-vancouver	numeric
-JCC Open	2212-0149	elsevier-vancouver	numeric
 Journal of Cardiovascular Computed Tomography	1934-5925	american-medical-association	numeric
 Journal of the American College of Clinical Wound Specialists	2213-5103	american-medical-association	numeric
 Journal of Communication Disorders	0021-9924	apa	author-date
-Journal of Cardiovascular Disease Research	0975-3583	american-medical-association	numeric
+Journal of Computational Design and Engineering	2288-4300	apa	author-date
 Journal of Clinical Epidemiology	0895-4356	elsevier-vancouver	numeric
 Journal of Clinical and Experimental Hepatology	0973-6883	american-medical-association	numeric
 Journal of Cystic Fibrosis	1569-1993	elsevier-vancouver	numeric
-HOMO - Journal of Comparative Human Biology	0018-442X	elsevier-harvard	author-date
+HOMO	0018-442X	elsevier-harvard	author-date
 Journal de Chirurgie Viscérale	1878-786X	elsevier-vancouver	numeric
 Cities	0264-2751	apa	author-date
 Journal of Criminal Justice	0047-2352	apa	author-date
@@ -998,7 +957,7 @@ Journal of Commodity Markets	2405-8513	elsevier-harvard	author-date
 Journal of Clinical Orthopaedics and Trauma	0976-5662	american-medical-association	numeric
 Journal of CO2 Utilization	2212-9820	elsevier-with-titles	numeric
 Journal of Cancer Policy	2213-5383	elsevier-with-titles	numeric
-Journal of Consumer Psychology	1057-7408	apa	author-date
+Journal of Computational Physics: X	2590-0552	elsevier-with-titles	numeric
 Crop Protection	0261-2194	elsevier-harvard	author-date
 Journal of Cancer Research and Practice	2311-3006	american-medical-association	numeric
 Cryogenics	0011-2275	elsevier-vancouver	numeric
@@ -1008,17 +967,15 @@ Journal of Clinical & Translational Endocrinology	2214-6237	elsevier-vancouver	n
 Journal of Clinical Tuberculosis and Other Mycobacterial Diseases	2405-5794	elsevier-vancouver	numeric
 Journal of Clinical Virology	1386-6532	elsevier-with-titles	numeric
 Cytotherapy	1465-3249	elsevier-vancouver	numeric
-Zoologischer Anzeiger - A Journal of Comparative Zoology	0044-5231	elsevier-harvard	author-date
+Zoologischer Anzeiger	0044-5231	elsevier-harvard	author-date
 Journal of Discrete Algorithms	1570-8667	elsevier-with-titles	numeric
-Journal of Diabetes and Its Complications	1056-8727	apa	author-date
-Journal of Disease Cause and Control	2452-2228	elsevier-vancouver	numeric
+Journal of Diabetes and Its Complications	1056-8727	american-medical-association	numeric
 JAAD Case Reports	2352-5126	american-medical-association	numeric
-Journal of Dermatology & Dermatologic Surgery	2352-2410	elsevier-harvard	author-date
 Journal of Drug Delivery Science and Technology	1773-2247	elsevier-with-titles	numeric
 Journal of Destination Marketing & Management	2212-571X	apa	author-date
+JMV-Journal de Médecine Vasculaire	2542-4513	elsevier-vancouver	numeric
 Japanese Dental Science Review	1882-7616	elsevier-vancouver	numeric
 Design Studies	0142-694X	apa	author-date
-Journal of Epidemiology	0917-5040	american-medical-association	numeric
 Journal of Electroanalytical Chemistry	1572-6657	elsevier-with-titles	numeric
 Journal of English for Academic Purposes	1475-1585	apa	author-date
 Journal of Economics and Business	0148-6195	apa	author-date
@@ -1029,7 +986,6 @@ Journal of Energy Chemistry	2095-4956	elsevier-without-titles	numeric
 Journal of Clinical and Translational Endocrinology: Case Reports	2214-6245	elsevier-vancouver	numeric
 Journal of the European Ceramic Society	0955-2219	elsevier-with-titles	numeric
 Journal of Ethnic Foods	2352-6181	elsevier-vancouver	numeric
-Journal of Economics, Finance and Administrative Science	2077-1886	apa	author-date
 Journal of Epidemiology and Global Health	2210-6006	elsevier-vancouver	numeric
 Electoral Studies	0261-3794	elsevier-harvard	author-date
 Journal of Experimental Marine Biology and Ecology	0022-0981	elsevier-harvard	author-date
@@ -1062,45 +1018,47 @@ Journal of Financial Stability	1572-3089	elsevier-harvard	author-date
 Futures	0016-3287	apa	author-date
 Fuel	0016-2361	elsevier-vancouver	numeric
 Journal of Global Antimicrobial Resistance	2213-7165	elsevier-vancouver	numeric
+Journal of Genetic Engineering and Biotechnology	1687-157X	elsevier-vancouver	numeric
 Global Environmental Change	0959-3780	elsevier-harvard	author-date
 Journal of Genetics and Genomics	1673-8527	elsevier-harvard	author-date
 Journal of Great Lakes Research	0380-1330	elsevier-harvard	author-date
+Journal of Geriatric Oncology	1879-4068	elsevier-vancouver	numeric
 Journal of Ginseng Research	1226-8453	elsevier-vancouver	numeric
-Journal de Gynécologie Obstétrique et Biologie de la Reproduction	0368-2315	elsevier-vancouver	numeric
 Health and Place	1353-8292	elsevier-harvard	author-date
 Journal of Health Economics	0167-6296	elsevier-harvard	author-date
 Journal of Hepatology	0168-8278	elsevier-vancouver	numeric
+JHEP Reports	2589-5559	elsevier-vancouver	numeric
 Journal of Hydro-environment Research	1570-6443	elsevier-harvard	author-date
 Journal of Hospitality, Leisure, Sport & Tourism Education	1473-8376	apa	author-date
 Journal of Hospitality and Tourism Management	1447-6770	apa	author-date
-Journal of Hospital Total Quality Management	2468-1202	elsevier-vancouver	numeric
 Journal of Inorganic Biochemistry	0162-0134	elsevier-with-titles	numeric
 Journal of Infection and Chemotherapy	1341-321X	elsevier-vancouver	numeric
 Journal of Indian College of Cardiology	1561-8811	american-medical-association	numeric
-Journal of Investigative Dermatology	0022-202X	elsevier-vancouver-author-date	author-date
-Journal of Innovation in Digital Ecosystems	2352-6645	elsevier-with-titles	numeric
+Journal of Investigative Dermatology	0022-202X	vancouver-author-date	author-date
+Journal d'imagerie diagnostique et interventionnelle	2543-3431	elsevier-vancouver	numeric
 Journal of Industrial Information Integration	2452-414X	elsevier-with-titles	numeric
 International Journal of Educational Research	0883-0355	apa	author-date
 International Journal of Fatigue	0142-1123	elsevier-vancouver	numeric
 International Journal of Refrigeration	0140-7007	elsevier-harvard	author-date
 Journal of Innovation & Knowledge	2444-569X	apa	author-date
 Journal of Immunological Methods	0022-1759	elsevier-harvard	author-date
+Journal of Interventional Medicine	2096-3602	american-medical-association	numeric
 Journal of International Money and Finance	0261-5606	elsevier-harvard	author-date
 Injury	0020-1383	elsevier-vancouver	numeric
 Journal of Infection and Public Health	1876-0341	elsevier-vancouver	numeric
-Journal of Information Security and Applications	2214-2126	elsevier-vancouver-author-date	author-date
-Journal of Investigative Dermatology Symposium Proceedings	1087-0024	elsevier-vancouver-author-date	author-date
+Journal of Information Security and Applications	2214-2126	elsevier-vancouver	numeric
+Journal of Investigative Dermatology Symposium Proceedings	1087-0024	vancouver-author-date	author-date
 Medical Engineering and Physics	1350-4533	elsevier-vancouver	numeric
 Journal of Cardiology	0914-5087	elsevier-vancouver	numeric
 Journal of Electromyography and Kinesiology	1050-6411	elsevier-harvard	author-date
 International Journal of Information Management	0268-4012	apa	author-date
 Journal of Dentistry	0300-5712	elsevier-with-titles	numeric
+Journal of Dentistry: X	2589-7004	elsevier-with-titles	numeric
 Journal of Process Control	0959-1524	elsevier-with-titles	numeric
 Journal of Retailing and Consumer Services	0969-6989	elsevier-harvard	author-date
 Journal of the Korean Statistical Society	1226-3192	apa	author-date
 Journal of King Saud University - Computer and Information Sciences	1319-1578	elsevier-harvard	author-date
 Journal of King Saud University - Engineering Sciences	1018-3639	elsevier-harvard	author-date
-Journal of King Saud University - Languages and Translation	2210-8319	elsevier-harvard	author-date
 Journal of King Saud University - Science	1018-3647	elsevier-harvard	author-date
 Journal of Logical and Algebraic Methods in Programming	2352-2208	elsevier-with-titles	numeric
 Learning and Instruction	0959-4752	apa	author-date
@@ -1110,7 +1068,6 @@ Journal of Macroeconomics	0164-0704	elsevier-harvard	author-date
 Materials & Design	0264-1275	elsevier-with-titles	numeric
 Molecular Aspects of Medicine	0098-2997	elsevier-harvard	author-date
 Journal of Materiomics	2352-8478	elsevier-vancouver	numeric
-Journal of Microscopy and Ultrastructure	2213-879X	elsevier-vancouver	numeric
 Journal of the Mechanical Behavior of Biomedical Materials	1751-6161	elsevier-harvard	author-date
 Mayo Clinic Proceedings	0025-6196	american-medical-association	numeric
 Journal of Molecular Graphics and Modelling	1093-3263	elsevier-with-titles	numeric
@@ -1120,10 +1077,9 @@ Journal of Manufacturing Processes	1526-6125	elsevier-vancouver	numeric
 Marine and Petroleum Geology	0264-8172	elsevier-harvard	author-date
 Marine Policy	0308-597X	elsevier-with-titles	numeric
 Journal of Materials Research and Technology	2238-7854	elsevier-vancouver	numeric
+Journal of Management Science and Engineering	2096-2320	apa	author-date
+Journal of Materials Science & Technology	1005-0302	elsevier-without-titles	numeric
 Journal of Manufacturing Systems	0278-6125	elsevier-vancouver	numeric
-Journal of Medical Ultrasound	0929-6441	elsevier-vancouver	numeric
-Journal des Maladies Vasculaires	0398-0499	elsevier-vancouver	numeric
-Journal of Northeast Agricultural University (English edition)	1006-8104	elsevier-vancouver-author-date	author-date
 The Journal of Nutritional Biochemistry	0955-2863	elsevier-vancouver	numeric
 Journal for Nature Conservation	1617-1381	apa	author-date
 Journal of the Egyptian National Cancer Institute	1110-0362	elsevier-vancouver	numeric
@@ -1136,12 +1092,10 @@ Journal of Nutrition & Intermediary Metabolism	2352-3859	elsevier-with-titles	nu
 Journal of the National Medical Association	0027-9684	american-medical-association	numeric
 Journal of Neonatal Nursing	1355-1841	elsevier-harvard	author-date
 Journal of Non-Newtonian Fluid Mechanics	0377-0257	elsevier-with-titles	numeric
-Journal of the Nigerian Mathematical Society	0189-8965	elsevier-vancouver	numeric
 Journal of Nursing Regulation	2155-8256	apa	author-date
 Journal of the Neurological Sciences	0022-510X	elsevier-with-titles	numeric
-Journal of Arrhythmia	1880-4276	elsevier-vancouver	numeric
 Journal of Oral Biosciences	1349-0079	elsevier-vancouver	numeric
-The Journal of Basic & Applied Zoology	2090-9896	elsevier-harvard	author-date
+Journal of Biosafety and Biosecurity	2588-9338	american-medical-association	numeric
 Journal of Oral Biology and Craniofacial Research	2212-4268	american-medical-association	numeric
 Journal of Building Engineering	2352-7102	elsevier-with-titles	numeric
 Journal of Cellular Immunotherapy	2352-1775	elsevier-vancouver	numeric
@@ -1150,24 +1104,24 @@ Journal of Current Ophthalmology	2452-2325	american-medical-association	numeric
 Journal of Obsessive-Compulsive and Related Disorders	2211-3649	apa	author-date
 Journal of Computational Science	1877-7503	elsevier-with-titles	numeric
 Journal of the Energy Institute	1743-9671	elsevier-with-titles	numeric
-Journal of the Egyptian Mathematical Society	1110-256X	elsevier-with-titles	numeric
 Journal of Economic Psychology	0167-4870	apa	author-date
 Journal of Ocean Engineering and Science	2468-0133	elsevier-without-titles	numeric
 Journal of Forensic Radiology and Imaging	2212-4780	elsevier-with-titles	numeric
 Journal of Obstetric, Gynecologic & Neonatal Nursing	0884-2175	apa	author-date
+Journal of Gynecology Obstetrics and Human Reproduction	2468-7847	elsevier-vancouver	numeric
 Journal of Informetrics	1751-1577	apa	author-date
+Journal of Integrative Medicine	2095-4964	elsevier-vancouver	numeric
 Optics and Laser Technology	0030-3992	elsevier-with-titles	numeric
 Journal of Organometallic Chemistry	0022-328X	elsevier-with-titles	numeric
-Journal of Men's Health	1875-6867	elsevier-vancouver	numeric
 Journal of Oral and Maxillofacial Surgery, Medicine, and Pathology	2212-5558	elsevier-vancouver	numeric
-Journal of Oncological Science	2452-3364	american-medical-association	numeric
-Journal of Palaeogeography	2095-3836	elsevier-harvard	author-date
-Journal of Pharmacy Research	0974-6943	american-medical-association	numeric
+Journal of Oncological Sciences	2452-3364	american-medical-association	numeric
 Journal of Orthopaedics	0972-978X	american-medical-association	numeric
+Journal of Stomatology oral and Maxillofacial Surgery	2468-7855	elsevier-vancouver	numeric
 Journal of Outdoor Recreation and Tourism	2213-0780	apa	author-date
 Journal of Orthopaedic Science	0949-2658	elsevier-vancouver	numeric
 Journal of Orthopaedic Translation	2214-031X	elsevier-vancouver	numeric
 Journal of Otology	1672-2930	elsevier-harvard	author-date
+Joule	2542-4351	elsevier-vancouver	numeric
 Journal of Pure and Applied Algebra	0022-4049	elsevier-with-titles	numeric
 Progress in Aerospace Sciences	0376-0421	elsevier-with-titles	numeric
 Journal of Photochemistry & Photobiology, B: Biology	1011-1344	elsevier-with-titles	numeric
@@ -1176,12 +1130,12 @@ Journal of Photochemistry & Photobiology, A: Chemistry	1010-6030	elsevier-with-t
 Physics and Chemistry of the Earth	1474-7065	elsevier-harvard	author-date
 Progress in Crystal Growth and Characterization of Materials	0960-8974	elsevier-with-titles	numeric
 Progress in Energy and Combustion Science	0360-1285	elsevier-vancouver	numeric
-Journal of Pierre Fauchard Academy (India Section)	0970-2199	american-medical-association	numeric
 Political Geography	0962-6298	apa	author-date
 Journal of Pharmaceutical Analysis	2095-1779	elsevier-with-titles	numeric
+Journal of Pharmacological Sciences	1347-8613	american-medical-association	numeric
 Journal of Physiotherapy	1836-9553	american-medical-association	numeric
 Journal of Plant Physiology	0176-1617	elsevier-harvard	author-date
-Progress in Lipid Research	0163-7827	elsevier-with-titles	numeric
+Progress in Lipid Research	0163-7827	elsevier-vancouver	numeric
 Journal of Pharmacological and Toxicological Methods	1056-8719	apa	author-date
 International Journal of Project Management	0263-7863	elsevier-harvard	author-date
 Progress in Materials Science	0079-6425	elsevier-vancouver	numeric
@@ -1199,39 +1153,38 @@ Journal of Photochemistry & Photobiology, C: Photochemistry Reviews	1389-5567	el
 JPRAS Open	2352-5878	american-medical-association	numeric
 Journal of Proteomics	1874-3919	elsevier-with-titles	numeric
 Progress in Retinal and Eye Research	1350-9462	elsevier-harvard	author-date
-Journal of Patient Safety & Infection Control	2214-207X	american-medical-association	numeric
 Progress in Solid State Chemistry	0079-6786	elsevier-vancouver	numeric
 Pharmacology and Therapeutics	0163-7258	apa	author-date
 Journal of Pediatric Urology	1477-5131	elsevier-vancouver	numeric
 Quaternary International	1040-6182	elsevier-harvard	author-date
 Quaternary Science Reviews	0277-3791	elsevier-harvard	author-date
 Journal of Quantitative Spectroscopy and Radiative Transfer	0022-4073	elsevier-vancouver	numeric
-Journal de Radiologie diagnostique et interventionnelle	2211-5706	elsevier-vancouver	numeric
-Journal of Reproductive Health and Medicine	2214-420X	american-medical-association	numeric
+Journal of Rare Earths	1002-0721	american-medical-association	numeric
 Journal of Reproductive Immunology	0165-0378	elsevier-harvard	author-date
 Radiology of Infectious Diseases	2352-6211	elsevier-vancouver	numeric
-Journal de réadaptation médicale	0242-648X	elsevier-vancouver	numeric
-Journal of Rock Mechanics and Geotechnical Engineering	1674-7755	elsevier-vancouver-author-date	author-date
+Journal of Rock Mechanics and Geotechnical Engineering	1674-7755	vancouver-author-date	author-date
 Resources Policy	0301-4207	elsevier-harvard	author-date
 Journal of Radiation Research and Applied Sciences	1687-8507	apa	author-date
 Journal of Rail Transport Planning & Management	2210-9706	elsevier-harvard	author-date
 Journal of Science: Advanced Materials and Devices	2468-2179	elsevier-with-titles	numeric
-Explore: The Journal of Science and Healing	1550-8307	american-medical-association	numeric
+EXPLORE	1550-8307	american-medical-association	numeric
 Journal of Saudi Chemical Society	1319-6103	elsevier-with-titles	numeric
 Studies in Educational Evaluation	0191-491X	apa	author-date
 Journal of the Saudi Heart Association	1016-7315	elsevier-vancouver	numeric
 Journal of Sustainable Mining	2300-3960	apa	author-date
 Journal of School Psychology	0022-4405	apa	author-date
 Space Policy	0265-9646	elsevier-with-titles	numeric
-Spine Deformity	2212-134X	elsevier-vancouver-author-date	author-date
+Spine Deformity	2212-134X	vancouver-author-date	author-date
 Journal of Statistical Planning and Inference	0378-3758	elsevier-harvard	author-date
 Journal of Safety Research	0022-4375	apa	author-date
 The Journal of Systems & Software	0164-1212	elsevier-harvard	author-date
 Journal of the Saudi Society of Agricultural Sciences	1658-077X	elsevier-harvard	author-date
 Communist and Post-Communist Studies	0967-067X	elsevier-harvard	author-date
+The Journal of Space Safety Engineering	2468-8967	elsevier-with-titles	numeric
 The Journal of Social Studies Research	0885-985X	apa	author-date
 Journal of Surgical Education	1931-7204	american-medical-association	numeric
 The Journal of Sexual Medicine	1743-6095	elsevier-vancouver	numeric
+Journal of Translational Autoimmunity	2589-9090	elsevier-with-titles	numeric
 Journal de Thérapie Comportementale et Cognitive	1155-1704	elsevier-vancouver	numeric
 Journal of Traditional Chinese Medicine	0254-6272	elsevier-vancouver	numeric
 Journal of Traditional and Complementary Medicine	2225-4110	american-medical-association	numeric
@@ -1248,20 +1201,17 @@ Tribology International	0301-679X	elsevier-vancouver	numeric
 Transport Policy	0967-070X	elsevier-harvard	author-date
 Journal de Traumatologie du Sport	0762-915X	elsevier-vancouver	numeric
 Journal of Traffic and Transportation Engineering (English Edition)	2095-7564	elsevier-harvard	author-date
-Journal of Taibah University for Science	1658-3655	elsevier-with-titles	numeric
 Journal of Tissue Viability	0965-206X	elsevier-vancouver	numeric
 Utilities Policy	0957-1787	elsevier-harvard	author-date
 Journal of Urban Management	2226-5856	apa	author-date
-Journal of Unconventional Oil and Gas Resources	2213-3976	elsevier-harvard	author-date
-Journal of Ultrasound	1971-3495	elsevier-vancouver	numeric
 Vaccine	0264-410X	elsevier-vancouver	numeric
-Value in Health	1098-3015	elsevier-vancouver	numeric
+Vaccine: X	2590-1362	elsevier-vancouver	numeric
+Value in Health	1098-3015	american-medical-association	numeric
 Journal of Veterinary Cardiology	1760-2734	elsevier-vancouver	numeric
-Journal of Veterinary Behavior: Clinical Applications and Research	1558-7878	elsevier-harvard	author-date
+Journal of Veterinary Behavior	1558-7878	elsevier-harvard	author-date
 Journal of Visceral Surgery	1878-7886	elsevier-vancouver	numeric
 Journal of Vascular Surgery Cases and Innovative Techniques	2468-4287	elsevier-vancouver	numeric
 Journal of Water Process Engineering	2214-7144	elsevier-with-titles	numeric
-Journal of Young Pharmacists	0975-1483	american-medical-association	numeric
 Karbala International Journal of Modern Science	2405-609X	elsevier-with-titles	numeric
 Kinésithérapie, la revue	1779-0123	elsevier-vancouver	numeric
 Kaohsiung Journal of Medical Sciences	1607-551X	elsevier-vancouver	numeric
@@ -1276,14 +1226,15 @@ Learning, Culture and Social Interaction	2210-6561	apa	author-date
 Learning and Individual Differences	1041-6080	apa	author-date
 The Leadership Quarterly	1048-9843	apa	author-date
 Legal Medicine	1344-6223	elsevier-with-titles	numeric
+Laparoscopic, Endoscopic and Robotic Surgery	2468-9009	american-medical-association	numeric
 Life Sciences	0024-3205	elsevier-with-titles	numeric
-Library Collections, Acquisitions and Technical Services	1464-9055	apa	author-date
 Library and Information Science Research	0740-8188	apa	author-date
 Limnologica	0075-9511	elsevier-harvard	author-date
 Linguistics and Education	0898-5898	apa	author-date
 Lingua	0024-3841	elsevier-harvard	author-date
+LITHOS	0024-4937	elsevier-harvard	author-date
+Liver Research	2542-5684	american-medical-association	numeric
 Livestock Science	1871-1413	elsevier-harvard	author-date
-Longevity Sciences and Medicine	2213-655X	elsevier-vancouver	numeric
 La Presse Médicale	0755-4982	elsevier-vancouver	numeric
 Leukemia Research	0145-2126	elsevier-with-titles	numeric
 Long Range Planning	0024-6301	elsevier-harvard	author-date
@@ -1294,7 +1245,6 @@ Journal of Luminescence	0022-2313	elsevier-with-titles	numeric
 Lung Cancer	0169-5002	elsevier-with-titles	numeric
 Materials Chemistry and Physics	0254-0584	elsevier-with-titles	numeric
 Mechanisms of Ageing and Development	0047-6374	elsevier-harvard	author-date
-Magister	0212-6796	apa	author-date
 Journal of Magnetism and Magnetic Materials	0304-8853	elsevier-with-titles	numeric
 Mammalian Biology	1616-5047	elsevier-harvard	author-date
 Mechanism and Machine Theory	0094-114X	elsevier-with-titles	numeric
@@ -1314,61 +1264,64 @@ Journal de mathématiques pures et appliquées	0021-7824	elsevier-with-titles	nu
 Materials Science in Semiconductor Processing	1369-8001	elsevier-with-titles	numeric
 Mathematical Social Sciences	0165-4896	elsevier-harvard	author-date
 Materials Today	1369-7021	elsevier-without-titles	numeric
+Matrix Biology Plus	2590-0285	elsevier-with-titles	numeric
 Mathematical Biosciences	0025-5564	elsevier-with-titles	numeric
+Molecular Catalysis	2468-8231	elsevier-with-titles	numeric
 Molecular and Cellular Endocrinology	0303-7207	elsevier-harvard	author-date
-Mathematical and Computer Modelling	0895-7177	elsevier-with-titles	numeric
 Materials Discovery	2352-9245	elsevier-with-titles	numeric
 Measurement	0263-2241	elsevier-with-titles	numeric
 Metabolic Engineering Communications	2214-0301	elsevier-harvard	author-date
 Mechatronics	0957-4158	elsevier-vancouver	numeric
 Mechanics of Materials	0167-6636	elsevier-harvard	author-date
 Médecine et Droit	1246-7391	elsevier-vancouver	numeric
-Medicina	1010-660X	elsevier-vancouver	numeric
+Medicine in Drug Discovery	2590-0986	elsevier-vancouver	numeric
 Medical Image Analysis	1361-8415	elsevier-harvard	author-date
 La revue de médecine légale	1878-6529	elsevier-vancouver	numeric
 Médecine et Maladies Infectieuses	0399-077X	elsevier-vancouver	numeric
+Medicine in Microecology	2590-0978	elsevier-vancouver	numeric
+Medicine in Novel Technology and Devices	2590-0935	elsevier-vancouver	numeric
 Médecine Nucléaire	0928-1258	elsevier-vancouver	numeric
 Médecine Palliative Soins de Support - Accompagnement - Ethique	1636-6522	elsevier-vancouver	numeric
-Medical Photonics	2213-8846	elsevier-harvard	author-date
 Medicina Reproductiva y Embriología Clínica	2340-9320	elsevier-harvard	author-date
 Microelectronic Engineering	0167-9317	elsevier-with-titles	numeric
 Infection, Genetics and Evolution	1567-1348	elsevier-harvard	author-date
+Middle East Fertility Society Journal	1110-5690	elsevier-with-titles	numeric
 Microelectronics Journal	0026-2692	elsevier-with-titles	numeric
 Métiers de la petite enfance	1258-780X	elsevier-vancouver	numeric
 Journal of Membrane Science	0376-7388	elsevier-with-titles	numeric
+Medicine in Omics	2590-1249	elsevier-vancouver	numeric
 Marine Environmental Research	0141-1136	elsevier-harvard	author-date
 Meat Science	0309-1740	apa	author-date
 Intermetallics	0966-9795	elsevier-with-titles	numeric
-Metamaterials	1873-1988	elsevier-with-titles	numeric
+Methods in Psychology	2590-2601	elsevier-harvard	author-date
+Metabolism Open	2589-9368	elsevier-vancouver	numeric
 MethodsX	2215-0161	elsevier-with-titles	numeric
 Manufacturing Letters	2213-8463	elsevier-vancouver	numeric
 Meta Gene	2214-5400	elsevier-harvard	author-date
 Mental Health & Prevention	2212-6570	apa	author-date
 Mental Health and Physical Activity	1755-2966	apa	author-date
 Microbes and Infection	1286-4579	elsevier-vancouver	numeric
-Microporous and Mesoporous Materials	1387-1811	elsevier-without-titles	numeric
+Microporous and Mesoporous Materials	1387-1811	elsevier-with-titles	numeric
 Microprocessors and Microsystems	0141-9331	elsevier-with-titles	numeric
 Microbiological Research	0944-5013	elsevier-harvard	author-date
 Microchemical Journal	0026-265X	elsevier-with-titles	numeric
 Journal of Microbiological Methods	0167-7012	elsevier-harvard	author-date
 Molecular Immunology	0161-5890	elsevier-harvard	author-date
-Mindfulness & Compassion	2445-4079	apa	author-date
 Minerals Engineering	0892-6875	elsevier-harvard	author-date
 International Journal of Mineral Processing	0301-7516	elsevier-harvard	author-date
-Methods in Oceanography	2211-1220	elsevier-harvard	author-date
 Mitochondrion	1567-7249	elsevier-harvard	author-date
-Medical Journal of Australia	0025-729X	elsevier-without-titles	numeric
 Medical Journal Armed Forces India	0377-1237	american-medical-association	numeric
 Materials Letters	0167-577X	elsevier-with-titles	numeric
+Materials Letters: X	2590-1508	elsevier-with-titles	numeric
 Medical Mycology Case Reports	2211-7539	elsevier-with-titles	numeric
+Micro and Nano Engineering	2590-0072	elsevier-with-titles	numeric
 Mechanisms of Development	0925-4773	elsevier-harvard	author-date
 Gene Expression Patterns	1567-133X	elsevier-harvard	author-date
+Molecular Astrophysics	2405-6758	elsevier-harvard	author-date
 Molecular & Biochemical Parasitology	0166-6851	elsevier-with-titles	numeric
-Journal of Molecular Catalysis. A, Chemical	1381-1169	elsevier-with-titles	numeric
-Journal of Molecular Catalysis. B, Enzymatic	1381-1177	elsevier-with-titles	numeric
 Molecular Cell	1097-2765	elsevier-harvard	author-date
+Molecular Data Science	2590-0633	elsevier-with-titles	numeric
 Journal of Molecular Liquids	0167-7322	elsevier-with-titles	numeric
-Molecular Oncology	1574-7891	elsevier-harvard	author-date
 Molecular Plant	1674-2052	american-medical-association	numeric
 Journal of Molecular Structure	0022-2860	elsevier-with-titles	numeric
 Journal of Monetary Economics	0304-3932	elsevier-harvard	author-date
@@ -1389,16 +1342,26 @@ Materials Science & Engineering A	0921-5093	elsevier-with-titles	numeric
 Multiple Sclerosis and Related Disorders	2211-0348	elsevier-harvard	author-date
 Materials Science & Engineering B	0921-5107	elsevier-with-titles	numeric
 Materials Science & Engineering C	0928-4931	elsevier-with-titles	numeric
+Materials Science for Energy Technologies	2589-2991	elsevier-with-titles	numeric
+Musculoskeletal Science and Practice	2468-7812	elsevier-harvard	author-date
 Médecine du Sommeil	1769-4493	elsevier-vancouver	numeric
-Procedia Materials Science	2211-8128	elsevier-with-titles	numeric
 Materials Science & Engineering R	0927-796X	elsevier-without-titles	numeric
+Materials Today Advances	2590-0498	elsevier-with-titles	numeric
+Materials Today Bio	2590-0064	elsevier-with-titles	numeric
+Materials Today Chemistry	2468-5194	elsevier-with-titles	numeric
 Materials Today Communications	2352-4928	elsevier-with-titles	numeric
+Materials Today Energy	2468-6069	elsevier-with-titles	numeric
 Materials Characterization	1044-5803	elsevier-with-titles	numeric
+Materialia	2589-1529	elsevier-with-titles	numeric
 International Journal of Machine Tools and Manufacture	0890-6955	elsevier-with-titles	numeric
+Materials Today Nano	2588-8420	elsevier-with-titles	numeric
+Materials Today Physics	2542-5293	elsevier-with-titles	numeric
+Materials Today Sustainability	2589-2347	elsevier-with-titles	numeric
 Journal of Multinational Financial Management	1042-444X	elsevier-harvard	author-date
 Mutation Research - Fundamental and Molecular Mechanisms of Mutagenesis	0027-5107	elsevier-with-titles	numeric
 Mutation Research - Genetic Toxicology and Environmental Mutagenesis	1383-5718	elsevier-with-titles	numeric
 Mutation Research-Reviews in Mutation Research	1383-5742	elsevier-with-titles	numeric
+Mycoscience	1340-3540	apa	author-date
 Journal de Mycologie Médicale	1156-5233	elsevier-vancouver	numeric
 Nonlinear Analysis	0362-546X	elsevier-with-titles	numeric
 Nonlinear Analysis: Hybrid Systems	1751-570X	elsevier-with-titles	numeric
@@ -1407,23 +1370,20 @@ Nano Energy	2211-2855	elsevier-with-titles	numeric
 Nano-Structures & Nano-Objects	2352-507X	elsevier-with-titles	numeric
 Nano Today	1748-0132	elsevier-with-titles	numeric
 Neurobiology of Aging	0197-4580	elsevier-harvard	author-date
+Neurobiology of Aging Science	2589-9589	elsevier-vancouver	numeric
 Neuroscience and Biobehavioral Reviews	0149-7634	elsevier-harvard	author-date
 Neurobiology of Sleep and Circadian Rhythms	2451-9944	elsevier-harvard	author-date
 New BIOTECHNOLOGY	1871-6784	elsevier-vancouver	numeric
 Neurochemistry International	0197-0186	elsevier-harvard	author-date
-Natureza & Conservação	1679-0073	elsevier-harvard	author-date
 Non-coding RNA Research	2468-0540	elsevier-with-titles	numeric
 New Astronomy	1384-1076	elsevier-harvard	author-date
 Nuclear Engineering and Design	0029-5493	elsevier-harvard	author-date
-Nefrología Latinoamericana	2444-9032	elsevier-vancouver	numeric
 Journal of Neurolinguistics	0911-6044	apa	author-date
 Nephrologie et Thérapeutique	1769-7255	elsevier-vancouver	numeric
-Neuroepigenetics	2214-7845	elsevier-harvard	author-date
-New Negatives in Plant Science	2352-0264	elsevier-with-titles	numeric
 Nuclear Engineering and Technology	1738-5733	elsevier-with-titles	numeric
 Neuropsychiatrie de l'enfance et de l'adolescence	0222-9617	elsevier-vancouver	numeric
 Neurochirurgie	0028-3770	elsevier-vancouver	numeric
-Neurophysiologie Clinique / Clinical Neurophysiology	0987-7053	elsevier-vancouver	numeric
+Neurophysiologie Clinique	0987-7053	elsevier-vancouver	numeric
 Neurocomputing	0925-2312	elsevier-with-titles	numeric
 European Neuropsychopharmacology	0924-977X	elsevier-harvard	author-date
 Journal of Neuroradiology	0150-9861	elsevier-vancouver	numeric
@@ -1432,17 +1392,10 @@ Neuron	0896-6273	elsevier-harvard	author-date
 Neurotoxicology	0161-813X	elsevier-harvard	author-date
 NFS Journal	2352-3646	elsevier-with-titles	numeric
 Natural Gas Industry B	2352-8540	elsevier-vancouver	numeric
-New Horizons in Clinical Case Reports	2352-9482	elsevier-with-titles	numeric
-New Horizons in Translational Medicine	2307-5023	elsevier-with-titles	numeric
-Nigerian Food Journal	0189-7241	elsevier-harvard	author-date
-Nigerian Journal of Genetics	0189-9686	elsevier-without-titles	numeric
-Nigerian Medical Journal	0300-1652	american-medical-association	numeric
-Nigerian Journal of Pharmaceutical Sciences	0189-322X	apa	author-date
 Nuclear Inst. and Methods in Physics Research, A	0168-9002	elsevier-with-titles	numeric
 Nuclear Inst. and Methods in Physics Research, B	0168-583X	elsevier-with-titles	numeric
 New Ideas in Psychology	0732-118X	apa	author-date
-Nigerian Journal Of Physiological Sciences	0794-859X	apa	author-date
-NJAS - Wageningen Journal of Life Sciences	1573-5214	elsevier-with-titles	numeric
+NJAS - Wageningen Journal of Life Sciences	1573-5214	elsevier-harvard	author-date
 International Journal of Non-Linear Mechanics	0020-7462	elsevier-with-titles	numeric
 Nuclear Medicine and Biology	0969-8051	elsevier-vancouver	numeric
 Neuromuscular Disorders	0960-8966	elsevier-vancouver	numeric
@@ -1450,9 +1403,11 @@ Nuclear Materials and Energy	2352-1791	elsevier-with-titles	numeric
 New Microbes and New Infections	2052-2975	elsevier-vancouver	numeric
 Neural Networks	0893-6080	apa	author-date
 Journal of Non-Crystalline Solids	0022-3093	elsevier-with-titles	numeric
+Journal of Non-Crystalline Solids: X	2590-1591	elsevier-with-titles	numeric
 Nonlinear Analysis: Real World Applications	1468-1218	elsevier-with-titles	numeric
 Neuropharmacology	0028-3908	elsevier-harvard	author-date
 Neurology, Psychiatry and Brain Research	0941-9500	apa	author-date
+Nanotechnology and Precision Engineering	2589-5540	american-medical-association	numeric
 NPG Neurologie - Psychiatrie - Gériatrie	1627-4830	elsevier-vancouver	numeric
 NursingPlus Open	2352-9008	apa	author-date
 Nuclear and Particle Physics Proceedings	2405-6014	elsevier-with-titles	numeric
@@ -1464,7 +1419,6 @@ Neuroscience Research	0168-0102	elsevier-harvard	author-date
 Neuropsychologia	0028-3932	elsevier-harvard	author-date
 Nutrition Research	0271-5317	elsevier-vancouver	numeric
 Neurotoxicology and Teratology	0892-0362	elsevier-harvard	author-date
-Nuclear Energy and Technology	2452-3038	elsevier-without-titles	numeric
 Journal of Nuclear Materials	0022-3115	elsevier-with-titles	numeric
 Nutrition, Metabolism and Cardiovascular Diseases	0939-4753	elsevier-vancouver	numeric
 Nuclear Physics, Section A	0375-9474	elsevier-with-titles	numeric
@@ -1478,18 +1432,22 @@ Ocean Modelling	1463-5003	elsevier-harvard	author-date
 Ocean and Coastal Management	0964-5691	elsevier-harvard	author-date
 Orthodontic Waves	1344-0241	elsevier-vancouver	numeric
 Ocean Engineering	0029-8018	elsevier-harvard	author-date
+Organic Geochemistry	0146-6380	elsevier-harvard	author-date
 HardwareX	2468-0672	elsevier-with-titles	numeric
 Optics and Lasers in Engineering	0143-8166	elsevier-vancouver	numeric
-Ortho Magazine	1262-4586	elsevier-vancouver	numeric
 Omega	0305-0483	elsevier-vancouver	numeric
 Oral and Maxillofacial Surgery Cases	2214-5419	elsevier-vancouver	numeric
+Molecular Therapy - Methods & Clinical Development	2329-0501	elsevier-vancouver	numeric
+Molecular Therapy - Nucleic Acids	2162-2531	elsevier-vancouver	numeric
+Molecular Therapy - Oncolytics	2372-7705	elsevier-vancouver	numeric
+Optical Materials: X	2590-1478	elsevier-with-titles	numeric
 OpenNano	2352-9520	elsevier-with-titles	numeric
 Critical Reviews in Oncology / Hematology	1040-8428	elsevier-harvard	author-date
-Revue d'Oncologie Hématologie Pédiatrique	2213-4670	elsevier-vancouver	numeric
 One Health	2352-7714	elsevier-with-titles	numeric
-Zeszyty Naukowe WCO, Letters in Oncology Science	1734-0489	elsevier-with-titles	numeric
+Oncology Signaling	2542-5633	american-medical-association	numeric
 Oral Oncology	1368-8375	elsevier-vancouver	numeric
 Oral Surgery, Oral Medicine, Oral Pathology and Oral Radiology	2212-4403	american-medical-association	numeric
+Opto-Electronics Review	1230-3402	elsevier-with-titles	numeric
 Journal of Operations Management	0272-6963	elsevier-harvard	author-date
 Operations Research Letters	0167-6377	elsevier-with-titles	numeric
 Optics Communications	0030-4018	elsevier-with-titles	numeric
@@ -1502,13 +1460,12 @@ Operations Research for Health Care	2211-6923	elsevier-with-titles	numeric
 Operations Research Perspectives	2214-7160	elsevier-vancouver	numeric
 International Orthodontics	1761-7227	elsevier-vancouver	numeric
 Optical Switching and Networking	1573-4277	elsevier-with-titles	numeric
-Otolaryngologia Polska	0030-6657	elsevier-vancouver	numeric
+Online Social Networks and Media	2468-6964	elsevier-with-titles	numeric
 Orthopaedics & Traumatology: Surgery & Research	1877-0568	elsevier-vancouver	numeric
 Oxymag	0990-1310	elsevier-vancouver	numeric
 Pacific-Basin Finance Journal	0927-538X	elsevier-harvard	author-date
 Photoacoustics	2213-5979	elsevier-with-titles	numeric
 Personality and Individual Differences	0191-8869	apa	author-date
-Pain	0304-3959	elsevier-vancouver	numeric
 Palaeogeography, Palaeoclimatology, Palaeoecology	0031-0182	elsevier-harvard	author-date
 Review of Palaeobotany and Palynology	0034-6667	elsevier-harvard	author-date
 Comptes rendus - Palevol	1631-0683	elsevier-harvard	author-date
@@ -1519,7 +1476,6 @@ Parallel Computing	0167-8191	elsevier-with-titles	numeric
 Parasite Epidemiology and Control	2405-6731	elsevier-harvard	author-date
 Parasitology International	1383-5769	elsevier-with-titles	numeric
 Particuology	1674-2001	apa	author-date
-Pathogenesis	2214-6636	elsevier-vancouver	numeric
 Pathophysiology	0928-4680	elsevier-with-titles	numeric
 Pattern Recognition Letters	0167-8655	elsevier-with-titles	numeric
 Journal of Pharmaceutical and Biomedical Analysis	0731-7085	elsevier-with-titles	numeric
@@ -1527,19 +1483,20 @@ Pharmacology, Biochemistry and Behavior	0091-3057	elsevier-harvard	author-date
 Primary Care Diabetes	1751-9918	elsevier-with-titles	numeric
 Perioperative Care and Operating Room Management	2405-6030	american-medical-association	numeric
 Journal of Physics and Chemistry of Solids	0022-3697	elsevier-with-titles	numeric
+Progress in Disaster Science	2590-0617	elsevier-vancouver	numeric
 Pediatric Dental Journal	0917-2394	elsevier-vancouver	numeric
 Photodiagnosis and Photodynamic Therapy	1572-1000	elsevier-with-titles	numeric
 Polymer Degradation and Stability	0141-3910	elsevier-with-titles	numeric
 Patient Education and Counseling	0738-3991	elsevier-with-titles	numeric
-International Journal of Pediatric Otorhinolaryngology Extra	1871-4048	elsevier-with-titles	numeric
+Perspectives in Ecology and Conservation	2530-0644	elsevier-harvard	author-date
+International Journal of Pediatric Otorhinolaryngology Case Reports	2588-9109	elsevier-with-titles	numeric
 Pedobiologia - Journal of Soil Ecology	0031-4056	elsevier-harvard	author-date
 International Journal of Pediatric Otorhinolaryngology	0165-5876	elsevier-with-titles	numeric
 Journal de pédiatrie et de puériculture	0987-7983	elsevier-vancouver	numeric
 Performance Enhancement & Health	2211-2669	apa	author-date
 Peptides	0196-9781	elsevier-with-titles	numeric
 Physics of the Earth and Planetary Interiors	0031-9201	elsevier-harvard	author-date
-Pediatria Polska	0031-3939	elsevier-vancouver	numeric
-Perspectives in Medicine	2211-968X	elsevier-with-titles	numeric
+Perfectionnement en Pédiatrie	2588-932X	elsevier-vancouver	numeric
 Petroleum	2405-6561	elsevier-with-titles	numeric
 Journal of Petroleum Science and Engineering	0920-4105	elsevier-harvard	author-date
 Performance Evaluation	0166-5316	elsevier-with-titles	numeric
@@ -1549,9 +1506,7 @@ Pharmacological Reports	1734-1140	elsevier-vancouver	numeric
 Annales Pharmaceutiques Françaises	0003-4509	elsevier-vancouver	numeric
 European Journal of Pharmaceutical Sciences	0928-0987	elsevier-harvard	author-date
 Physiology & Behavior	0031-9384	elsevier-with-titles	numeric
-Pharmacognosy Journal	0975-3575	american-medical-association	numeric
 Le Pharmacien Hospitalier et Clinicien	2211-1042	elsevier-vancouver	numeric
-Pharmaceutical Methods	2229-4708	american-medical-association	numeric
 Physics in Medicine	2352-4510	elsevier-with-titles	numeric
 Pediatric Hematology Oncology Journal	2468-1245	elsevier-vancouver	numeric
 ISPRS Journal of Photogrammetry and Remote Sensing	0924-2716	elsevier-harvard	author-date
@@ -1563,13 +1518,11 @@ Physica B: Physics of Condensed Matter	0921-4526	elsevier-with-titles	numeric
 Physica C: Superconductivity and its applications	0921-4534	elsevier-with-titles	numeric
 Physica D: Nonlinear Phenomena	0167-2789	elsevier-with-titles	numeric
 Physica E: Low-dimensional Systems and Nanostructures	1386-9477	elsevier-with-titles	numeric
-Journal of Physiology - Paris	0928-4257	elsevier-harvard	author-date
 Physiotherapy	0031-9406	elsevier-vancouver	numeric
 Phytochemistry	0031-9422	elsevier-harvard	author-date
 Phytochemistry Letters	1874-3900	elsevier-harvard	author-date
 Journal of Psychiatric Research	0022-3956	elsevier-harvard	author-date
-Pediatric Infectious Disease	2212-8328	american-medical-association	numeric
-Postępy Psychiatrii i Neurologii	1230-2813	elsevier-vancouver	numeric
+Mayo Clinic Proceedings: Innovations, Quality & Outcomes	2542-4548	american-medical-association	numeric
 Perspectives in Science	2213-0209	elsevier-harvard	author-date
 Neurologia i Neurochirurgia Polska	0028-3843	elsevier-vancouver	numeric
 Physics Letters A	0375-9601	elsevier-with-titles	numeric
@@ -1585,24 +1538,20 @@ Personalized Medicine in Psychiatry	2468-1717	elsevier-vancouver	numeric
 PM&R	1934-1482	elsevier-vancouver	numeric
 Personalized Medicine Universe	2186-4950	elsevier-vancouver	numeric
 Psychoneuroendocrinology	0306-4530	elsevier-harvard	author-date
-Revue de Pneumologie clinique	0761-8417	elsevier-vancouver	numeric
 Photonics and Nanostructures - Fundamentals and Applications	1569-4410	elsevier-with-titles	numeric
 Progress in Neuropsychopharmacology & Biological Psychiatry	0278-5846	elsevier-harvard	author-date
 Progress in Natural Science: Materials International	1002-0071	elsevier-with-titles	numeric
 Pediatric Neurology	0887-8994	elsevier-vancouver	numeric
-Polish Annals of Medicine	1230-8013	american-medical-association	numeric
 Progress in Organic Coatings	0300-9440	elsevier-with-titles	numeric
 Poetics	0304-422X	apa	author-date
 Polar Science	1873-9652	elsevier-harvard	author-date
 European Journal of Political Economy	0176-2680	elsevier-harvard	author-date
-Policy and Society	1449-4035	apa	author-date
 Polyhedron	0277-5387	elsevier-with-titles	numeric
 Postharvest Biology and Technology	0925-5214	elsevier-harvard	author-date
 Polymer Testing	0142-9418	elsevier-with-titles	numeric
 Journal of Power Sources	0378-7753	elsevier-with-titles	numeric
 Progress in Pediatric Cardiology	1058-9813	elsevier-vancouver	numeric
 Perspectives in Plant Ecology, Evolution and Systematics	1433-8319	elsevier-harvard	author-date
-Polski Przegląd Otorynolaryngologiczny	2084-5308	elsevier-vancouver	numeric
 Pattern Recognition	0031-3203	elsevier-with-titles	numeric
 Journal of Pragmatics	0378-2166	elsevier-harvard	author-date
 Pratique Neurologique - FMC	1878-7762	elsevier-vancouver	numeric
@@ -1610,6 +1559,7 @@ Pratiques en nutrition	1766-7305	elsevier-vancouver	numeric
 Le Praticien en anesthésie réanimation	1279-7960	elsevier-vancouver	numeric
 Process Biochemistry	1359-5113	elsevier-with-titles	numeric
 Parkinsonism and Related Disorders	1353-8020	elsevier-with-titles	numeric
+Clinical Parkinsonism & Related Disorders	2590-1125	elsevier-with-titles	numeric
 Precision Engineering	0141-6359	elsevier-vancouver	numeric
 Precambrian Research	0301-9268	elsevier-harvard	author-date
 Pregnancy Hypertension: An International Journal of Women's Cardiovascular Health	2210-7789	elsevier-with-titles	numeric
@@ -1618,7 +1568,6 @@ Preventive Veterinary Medicine	0167-5877	elsevier-harvard	author-date
 Prostate International	2287-8882	american-medical-association	numeric
 Prostaglandins and Other Lipid Mediators	1098-8823	elsevier-with-titles	numeric
 International Journal of Production Economics	0925-5273	elsevier-harvard	author-date
-Procedia Early Career Research	2405-8815	elsevier-harvard	author-date
 Progress in Histochemistry and Cytochemistry	0079-6336	elsevier-with-titles	numeric
 Procedia Manufacturing	2351-9789	elsevier-without-titles	numeric
 Progress in Neurobiology	0301-0082	elsevier-harvard	author-date
@@ -1630,68 +1579,65 @@ Pathology - Research and Practice	0344-0338	elsevier-with-titles	numeric
 Pratiques psychologiques	1269-1763	apa	author-date
 Practical Radiation Oncology	1879-8500	american-medical-association	numeric
 Progress in Surface Science	0079-6816	elsevier-with-titles	numeric
-Pacific Science Review	1229-5450	elsevier-with-titles	numeric
-Psicología Educativa	1135-755X	apa	author-date
 Process Safety and Environmental Protection	0957-5820	elsevier-harvard	author-date
 Psychologie française	0033-2984	apa	author-date
-Psychosocial Intervention	1132-0559	apa	author-date
+Revista de Psicodidáctica	1136-1034	apa	author-date
+Revista de Psicodidáctica (English ed.)	2530-3805	apa	author-date
 Plant Science	0168-9452	elsevier-with-titles	numeric
 Journal of Psychosomatic Research	0022-3999	elsevier-with-titles	numeric
-Pacific Science Review A: Natural Science and Engineering	2405-8823	elsevier-with-titles	numeric
-Pacific Science Review B: Humanities and Social Sciences	2405-8831	elsevier-harvard	author-date
 Planetary and Space Science	0032-0633	elsevier-harvard	author-date
 Psychiatry Research	0165-1781	elsevier-harvard	author-date
 Psychiatry Research: Neuroimaging	0925-4927	elsevier-harvard	author-date
 Psychology of Sport & Exercise	1469-0292	apa	author-date
 Pharmacy Today	1042-0991	elsevier-with-titles	numeric
 Powder Technology	0032-5910	elsevier-with-titles	numeric
+Petroleum Research	2096-2495	elsevier-harvard	author-date
 Journal of Public Economics	0047-2727	elsevier-harvard	author-date
-Public Health Forum	0944-5587	elsevier-vancouver-author-date	author-date
 Public Relations Review	0363-8111	apa	author-date
 Progrès en Urologie	1166-7087	elsevier-vancouver	numeric
 Journal of Purchasing and Supply Management	1478-4092	elsevier-harvard	author-date
 Papillomavirus Research	2405-8521	elsevier-with-titles	numeric
 Quarterly Review of Economics and Finance	1062-9769	apa	author-date
 Quaternary Geochronology	1871-1014	elsevier-harvard	author-date
-Quaderni Italiani di Psichiatria	0393-0645	elsevier-vancouver	numeric
 Research in Accounting Regulation	1052-0457	apa	author-date
 Radiology Case Reports	1930-0433	elsevier-vancouver	numeric
 Radiotherapy and Oncology	0167-8140	elsevier-vancouver	numeric
-RAI Revista de Administração e Inovação	1809-2039	apa	author-date
 Rangeland Ecology & Management	1550-7424	elsevier-harvard	author-date
 Research in Autism Spectrum Disorders	1750-9467	apa	author-date
-Revista de Administração	0080-2107	apa	author-date
-Revista Brasileira de Ciências do Esporte	0101-3289	elsevier-vancouver-author-date	author-date
+RAUSP Management Journal	2531-0488	apa	author-date
+Revista Brasileira de Ciências do Esporte	0101-3289	vancouver-author-date	author-date
 Revista Brasileira de Entomologia	0085-5626	elsevier-harvard	author-date
 Reproductive BioMedicine Online	1472-6483	elsevier-harvard	author-date
 Reproductive Biomedicine & Society Online	2405-6618	elsevier-harvard	author-date
-Robotics and Computer Integrated Manufacturing	0736-5845	elsevier-with-titles	numeric
+Robotics and Computer-Integrated Manufacturing	0736-5845	elsevier-with-titles	numeric
 Revue de Chirurgie Orthopedique et Traumatologique	1877-0517	elsevier-vancouver	numeric
-Revista de Contabilidad	1138-4891	apa	author-date
 Review of Development Finance	1879-9337	elsevier-harvard	author-date
-REACH - Reviews in Human Space Exploration	2352-3093	elsevier-vancouver	numeric
+REACH	2352-3093	elsevier-vancouver	numeric
 Reactive and Functional Polymers	1381-5148	elsevier-with-titles	numeric
+Revista Española de Cardiología (English Edition)	1885-5857	american-medical-association	numeric
+Revista Española de Cardiología	0300-8932	american-medical-association	numeric
+Results in Chemistry	2211-7156	elsevier-with-titles	numeric
 Resources, Conservation & Recycling	0921-3449	elsevier-harvard	author-date
-European Journal of Management and Business Economics	2444-8451	apa	author-date
 Redox Biology	2213-2317	elsevier-with-titles	numeric
 Renewable Energy Focus	1755-0084	elsevier-without-titles	numeric
-Resource-Efficient Technologies	2405-6537	elsevier-with-titles	numeric
 Revue francophone internationale de recherche infirmière	2352-8028	elsevier-vancouver	numeric
-REGE - Revista de Gestão	1809-2276	apa	author-date
+Revue Francophone de Cicatrisation	2468-9114	elsevier-vancouver	numeric
 Regional Science and Urban Economics	0166-0462	elsevier-harvard	author-date
-Regulatory Peptides	0167-0115	elsevier-vancouver	numeric
+Journal of Immunology and Regenerative Medicine	2468-4988	american-medical-association	numeric
 Annals of Physical and Rehabilitation Medicine	1877-0657	elsevier-vancouver	numeric
 Renewable Energy	0960-1481	elsevier-with-titles	numeric
 Reproductive Biology	1642-431X	elsevier-vancouver	numeric
 Reinforced Plastics	0034-3617	elsevier-without-titles	numeric
+Research Policy: X	2590-1451	elsevier-harvard	author-date
 Resource and Energy Economics	0928-7655	elsevier-harvard	author-date
+Research in Globalization	2590-051X	apa	author-date
+Respiratory Investigation	2212-5345	elsevier-vancouver	numeric
+Respiratory Medicine and Research	2590-0412	elsevier-vancouver	numeric
 Research in Microbiology	0923-2508	elsevier-vancouver	numeric
 Revue d'Epidemiologie et de Santé Publique	0398-7620	elsevier-vancouver	numeric
 Respiratory Physiology & Neurobiology	1569-9048	elsevier-harvard	author-date
 Research Policy	0048-7333	elsevier-harvard	author-date
 Reliability Engineering and System Safety	0951-8320	elsevier-vancouver	numeric
-Revista de la educación superior	0185-2760	apa	author-date
-Resuscitation	0300-9572	elsevier-vancouver	numeric
 Regenerative Therapy	2352-3204	elsevier-vancouver	numeric
 Current Research in Translational Medicine	2452-3186	elsevier-vancouver	numeric
 Research in Transportation Economics	0739-8859	apa	author-date
@@ -1706,33 +1652,26 @@ Revue de micropaléontologie	0035-1598	elsevier-harvard	author-date
 Revue du podologue	1766-7313	elsevier-vancouver	numeric
 Revue du rhumatisme	1169-8330	elsevier-vancouver	numeric
 La revue de santé scolaire et universitaire	1879-3991	elsevier-vancouver	numeric
-Revue de Stomatologie, de Chirurgie Maxillo-faciale et de Chirurgie Orale	2213-6533	elsevier-vancouver	numeric
 Revue Francophone d'Orthoptie	1876-2204	elsevier-vancouver	numeric
 Russian Geology and Geophysics	1068-7971	elsevier-harvard	author-date
 La Revue Gestion et Organisation	2214-4234	apa	author-date
 Rhizosphere	2452-2198	elsevier-harvard	author-date
-RIBAGUA - Revista Iberoamericana del Agua	2386-3781	elsevier-vancouver	numeric
 Research in International Business and Finance	0275-5319	elsevier-harvard	author-date
 Research in Developmental Disabilities	0891-4222	apa	author-date
-Revista Internacional de Métodos Numéricos para Cálculo y Diseño en Ingeniería	0213-1315	elsevier-with-titles	numeric
-Results in Immunology	2211-2839	elsevier-with-titles	numeric
+Results in Applied Mathematics	2590-0374	elsevier-vancouver	numeric
+Results in Engineering	2590-1230	elsevier-with-titles	numeric
+Results in Materials	2590-048X	elsevier-with-titles	numeric
 Results in Physics	2211-3797	elsevier-vancouver	numeric
-Results in Pharma Sciences	2211-2863	elsevier-with-titles	numeric
 Research in Organizational Behavior	0191-3085	apa	author-date
-Revista Iberoamericana de Psicología y Salud	2171-2069	apa	author-date
 Revista de Logopedia, Foniatría y Audiología	0214-4603	apa	author-date
-Revista Latinoamericana de Psicología	0120-0534	apa	author-date
 Radiation Measurements	1350-4487	elsevier-harvard	author-date
-Revista Mexicana de Biodiversidad	1870-3453	apa	author-date
 Revista Médica Clínica Las Condes	0716-8640	elsevier-vancouver	numeric
 Respiratory Medicine Case Reports	2213-0071	elsevier-with-titles	numeric
 International Journal of Refractory Metals and Hard Materials	0263-4368	elsevier-with-titles	numeric
 International Journal of Rock Mechanics and Mining Sciences	1365-1609	american-medical-association	numeric
 Revue des Maladies Respiratoires	0761-8425	elsevier-vancouver	numeric
-Revista Mexicana de Trastornos Alimentarios	2007-1523	apa	author-date
 Robotics and Autonomous Systems	0921-8890	elsevier-with-titles	numeric
 Radiation Physics and Chemistry	0969-806X	elsevier-harvard	author-date
-Revista de Psicología del Trabajo y de las Organizaciones	1576-5962	apa	author-date
 Research in Social and Administrative Pharmacy	1551-7411	american-medical-association	numeric
 Remote Sensing Applications: Society and Environment	2352-9385	elsevier-harvard	author-date
 Remote Sensing of Environment	0034-4257	elsevier-harvard	author-date
@@ -1761,19 +1700,19 @@ Sensing and Bio-Sensing Research	2214-1804	elsevier-with-titles	numeric
 Soins Cadres	0183-2980	elsevier-vancouver	numeric
 Scandinavian Journal of Management	0956-5221	apa	author-date
 Schizophrenia Research	0920-9964	elsevier-harvard	author-date
+Scientific African	2468-2276	elsevier-with-titles	numeric
+Science Bulletin	2095-9273	elsevier-vancouver	numeric
 Science of Computer Programming	0167-6423	elsevier-with-titles	numeric
 Science & Justice	1355-0306	elsevier-with-titles	numeric
 Science et Sports	0765-1597	elsevier-vancouver	numeric
 Systems & Control Letters	0167-6911	elsevier-with-titles	numeric
 Schizophrenia Research: Cognition	2215-0013	elsevier-harvard	author-date
-Studies in Communication Sciences	1424-4896	apa	author-date
 Sustainable Chemistry and Pharmacy	2352-5541	elsevier-harvard	author-date
 Stem Cell Research	1873-5061	elsevier-harvard	author-date
 Sustainable Cities and Society	2210-6707	apa	author-date
 Surface & Coatings Technology	0257-8972	elsevier-with-titles	numeric
 Soil Dynamics and Earthquake Engineering	0267-7261	elsevier-vancouver	numeric
 The Saudi Dental Journal	1013-9052	elsevier-harvard	author-date
-Singapore Dental Journal	0377-5291	elsevier-with-titles	numeric
 Solar Energy	0038-092X	elsevier-harvard	author-date
 Journal of Sea Research	1385-1101	elsevier-harvard	author-date
 Journal of Second Language Writing	1060-3743	apa	author-date
@@ -1782,10 +1721,9 @@ Sustainable Energy, Grids and Networks	2352-4677	elsevier-with-titles	numeric
 Separation and Purification Technology	1383-5866	elsevier-with-titles	numeric
 Socio-Economic Planning Sciences	0038-0121	elsevier-vancouver	numeric
 Sustainable Environment Research	2468-2039	elsevier-vancouver	numeric
-Serials Review	0098-7913	apa	author-date
 Solid Earth Sciences	2451-912X	elsevier-harvard	author-date
 Sustainable Energy Technologies and Assessments	2213-1388	elsevier-vancouver	numeric
-Sexologies	1158-1360	elsevier-vancouver-author-date	author-date
+Sexologies	1158-1360	vancouver-author-date	author-date
 Seminars in Fetal and Neonatal Medicine	1744-165X	elsevier-vancouver	numeric
 Journal of Structural Geology	0191-8141	elsevier-harvard	author-date
 Soins Gérontologie	1268-6034	elsevier-vancouver	numeric
@@ -1796,9 +1734,8 @@ Studies in History and Philosophy of Biol & Biomed Sci	1369-8486	apa	author-date
 Signal Processing	0165-1684	elsevier-with-titles	numeric
 Simulation Modelling Practice and Theory	1569-190X	elsevier-with-titles	numeric
 Saudi Journal of Biological Sciences	1319-562X	elsevier-harvard	author-date
-Spanish Journal of Marketing - ESIC	2444-9695	apa	author-date
-Scandinavian Journal of Pain	1877-8860	elsevier-vancouver	numeric
 Sleep Medicine	1389-9457	elsevier-vancouver	numeric
+Sleep Medicine: X	2590-1427	elsevier-vancouver	numeric
 Sleep Health: Journal of the National Sleep Foundation	2352-7218	american-medical-association	numeric
 Smart Health	2352-6483	apa	author-date
 Scripta Materialia	1359-6462	elsevier-without-titles	numeric
@@ -1808,31 +1745,29 @@ Sensors & Actuators: B. Chemical	0925-4005	elsevier-with-titles	numeric
 Surgical Oncology	0960-7404	elsevier-with-titles	numeric
 Surgery for Obesity and Related Diseases	1550-7289	elsevier-vancouver	numeric
 The Social Science Journal	0362-3319	apa	author-date
-Sociologie du travail	0038-0296	elsevier-harvard	author-date
 SoftwareX	2352-7110	elsevier-vancouver	numeric
 Soins	0038-0814	elsevier-vancouver	numeric
 Solar Energy Materials and Solar Cells	0927-0248	elsevier-with-titles	numeric
 Social Networks	0378-8733	elsevier-harvard	author-date
-Surveys in Operations Research and Management Science	1876-7354	elsevier-with-titles	numeric
+Surgery Open Science	2589-8450	elsevier-vancouver	numeric
 Solid State Ionics	0167-2738	elsevier-with-titles	numeric
 Spatial Statistics	2211-6753	elsevier-harvard	author-date
 Sustainable Production and Consumption	2352-5509	elsevier-harvard	author-date
 Speech Communication	0167-6393	elsevier-harvard	author-date
 The Spine Journal	1529-9430	elsevier-vancouver	numeric
 Saudi Pharmaceutical Journal	1319-0164	elsevier-harvard	author-date
-St. Petersburg Polytechnical University Journal: Physics and Mathematics	2405-7223	elsevier-with-titles	numeric
 Soins Pédiatrie/Puériculture	1259-4792	elsevier-vancouver	numeric
 Journal of Stored Products Research	0022-474X	elsevier-harvard	author-date
 Soins Psychiatrie	0241-6972	elsevier-vancouver	numeric
-The Spanish Review of Financial Economics	2173-1268	elsevier-harvard	author-date
 Sexual & Reproductive Healthcare	1877-5756	elsevier-vancouver	numeric
+Social Sciences & Humanities Open	2590-2911	apa	author-date
 Solid State Communications	0038-1098	elsevier-with-titles	numeric
-Sleep Science	1984-0063	elsevier-vancouver	numeric
 Solid State Electronics	0038-1101	elsevier-vancouver	numeric
+Solid State Electronics Letters	2589-2088	elsevier-with-titles	numeric
 Social Science & Medicine	0277-9536	elsevier-harvard	author-date
 SSM - Population Health	2352-8273	apa	author-date
 Solid State Sciences	1293-2558	elsevier-with-titles	numeric
-Spatial and Spatio-temporal Epidemiology	1877-5845	elsevier-vancouver-author-date	author-date
+Spatial and Spatio-temporal Epidemiology	1877-5845	vancouver-author-date	author-date
 Statistics and Probability Letters	0167-7152	elsevier-harvard	author-date
 Steroids	0039-128X	elsevier-with-titles	numeric
 Cell Stem Cell	1934-5909	elsevier-harvard	author-date
@@ -1843,15 +1778,12 @@ Science of the Total Environment	0048-9697	elsevier-harvard	author-date
 Structural Change and Economic Dynamics	0954-349X	elsevier-harvard	author-date
 Journal of Strategic Information Systems	0963-8687	elsevier-harvard	author-date
 Structural Safety	0167-4730	elsevier-vancouver	numeric
-Suma de Negocios	2215-910X	apa	author-date
-Suma Psicológica	0121-4381	apa	author-date
 The Journal of Supercritical Fluids	0896-8446	elsevier-with-titles	numeric
 Surfaces and Interfaces	2468-0230	elsevier-with-titles	numeric
 Surface Science	0039-6028	elsevier-with-titles	numeric
 Sustainable Computing: Informatics and Systems	2210-5379	elsevier-with-titles	numeric
 Sustainable Materials and Technologies	2214-9937	elsevier-with-titles	numeric
 Surface Science Reports	0167-5729	elsevier-with-titles	numeric
-Sustainability of Water Quality and Ecology	2212-6139	elsevier-harvard	author-date
 Swarm and Evolutionary Computation	2210-6502	elsevier-with-titles	numeric
 Sexual Medicine Reviews	2050-0521	elsevier-vancouver	numeric
 Synthetic and Systems Biotechnology	2405-805X	elsevier-vancouver	numeric
@@ -1862,24 +1794,23 @@ Journal of Systems Architecture	1383-7621	elsevier-with-titles	numeric
 Trends in Anaesthesia and Critical Care	2210-8440	elsevier-with-titles	numeric
 Theoretical and Applied Fracture Mechanics	0167-8442	elsevier-with-titles	numeric
 Talanta	0039-9140	elsevier-with-titles	numeric
-Theoretical and Applied Mechanics Letters	2095-0349	elsevier-with-titles	numeric
 Teaching and Teacher Education	0742-051X	apa	author-date
 Journal of Thermal Biology	0306-4565	elsevier-harvard	author-date
 Travel Behaviour and Society	2214-367X	elsevier-harvard	author-date
 Thermochimica Acta	0040-6031	elsevier-with-titles	numeric
-Trends in Cardiovascular Medicine	1050-1738	elsevier-vancouver-author-date	author-date
-Tzu Chi Medical Journal	1016-3190	elsevier-vancouver	numeric
+Trends in Cardiovascular Medicine	1050-1738	elsevier-vancouver	numeric
 Trauma Case Reports	2352-6440	elsevier-with-titles	numeric
+Tropical Cyclone Research and Review	2225-6032	elsevier-harvard	author-date
 Theoretical Computer Science	0304-3975	elsevier-with-titles	numeric
-Tanta Dental Journal	1687-8574	elsevier-vancouver	numeric
+The Cell Surface	2468-2330	elsevier-harvard	author-date
 Trends in Environmental Analytical Chemistry	2214-1588	elsevier-with-titles	numeric
 Technovation	0166-4972	elsevier-harvard	author-date
 Tectonophysics	0040-1951	elsevier-harvard	author-date
-TÉKHNE - Review of Applied Management Studies	1645-9911	apa	author-date
 Telematics and Informatics	0736-5853	elsevier-harvard	author-date
 Teaching and Learning in Nursing	1557-3087	apa	author-date
 Journal of Terramechanics	0022-4898	elsevier-harvard	author-date
-Tetrahedron Letters	0040-4039	elsevier-without-titles	numeric
+Tetrahedron	0040-4020	elsevier-with-titles	numeric
+Tetrahedron Letters	0040-4039	elsevier-with-titles	numeric
 Technological Forecasting & Social Change	0040-1625	elsevier-harvard	author-date
 Theriogenology	0093-691X	elsevier-vancouver	numeric
 The Knee	0968-0160	elsevier-vancouver	numeric
@@ -1892,15 +1823,16 @@ Technology in Society	0160-791X	elsevier-with-titles	numeric
 Toxicology in Vitro	0887-2333	elsevier-harvard	author-date
 Turkish Journal of Emergency Medicine	2452-2473	american-medical-association	numeric
 The Journal for Nurse Practitioners	1555-4155	american-medical-association	numeric
-Taiwan Journal of Ophthalmology	2211-5056	american-medical-association	numeric
 Taiwanese Journal of Obstetrics & Gynecology	1028-4559	elsevier-vancouver	numeric
+Translational Medicine of Aging	2468-5011	elsevier-with-titles	numeric
 Travel Medicine and Infectious Disease	1477-8939	elsevier-vancouver	numeric
-Translational Medicine in Diabetes, Lipids and Cardiovascular Prevention	2214-7543	elsevier-with-titles	numeric
 Tourism Management Perspectives	2211-9736	apa	author-date
+Translational Metabolic Syndrome Research	2588-9303	american-medical-association	numeric
 Topology and its Applications	0166-8641	elsevier-with-titles	numeric
 Toxicology	0300-483X	elsevier-harvard	author-date
 Toxicologie Analytique et Clinique	2352-0078	elsevier-vancouver	numeric
 Toxicon	0041-0101	elsevier-harvard	author-date
+Toxicon: X	2590-1710	elsevier-harvard	author-date
 Toxicology Letters	0378-4274	elsevier-harvard	author-date
 Toxicology Reports	2214-7500	elsevier-with-titles	numeric
 Transplantation Reports	2451-9596	elsevier-with-titles	numeric
@@ -1916,14 +1848,14 @@ Alzheimer's & Dementia: Translational Research & Clinical Interventions	2352-873
 Transportation Research Part D	1361-9209	elsevier-harvard	author-date
 Transportation Research Part E	1366-5545	elsevier-harvard	author-date
 Transportation Research Part F: Psychology and Behaviour	1369-8478	apa	author-date
-Transportation Geotechnics	2214-3912	elsevier-vancouver-author-date	author-date
+Transportation Geotechnics	2214-3912	elsevier-vancouver	numeric
 Translational Research in Anatomy	2214-854X	elsevier-with-titles	numeric
 Transplant Immunology	0966-3274	elsevier-with-titles	numeric
-CAAI Transactions on Intelligence Technology	2468-2322	elsevier-without-titles	numeric
+Transportation Research Interdisciplinary Perspectives	2590-1982	elsevier-harvard	author-date
 Transactions of A. Razmadze Mathematical Institute	2346-8092	elsevier-with-titles	numeric
 Transportation Research Procedia	2352-1465	elsevier-harvard	author-date
-Translational Proteomics	2212-9626	elsevier-with-titles	numeric
 Thinking Skills and Creativity	1871-1871	apa	author-date
+Thermal Science and Engineering Progress	2451-9049	elsevier-with-titles	numeric
 Thin Solid Films	0040-6090	elsevier-with-titles	numeric
 Ticks and Tick-borne Diseases	1877-959X	elsevier-harvard	author-date
 Tunnelling and Underground Space Technology incorporating Trenchless Technology Research	0886-7798	elsevier-harvard	author-date
@@ -1933,55 +1865,57 @@ Urban Forestry & Urban Greening	1618-8667	elsevier-harvard	author-date
 Ultramicroscopy	0304-3991	elsevier-with-titles	numeric
 Ultrasonics	0041-624X	elsevier-with-titles	numeric
 Ultrasonics - Sonochemistry	1350-4177	elsevier-with-titles	numeric
-UMK Procedia	2214-0115	apa	author-date
 Underground Space	2467-9674	apa	author-date
 Urology	0090-4295	american-medical-association	numeric
 Urologic Oncology: Seminars and Original Investigations	1078-1439	elsevier-vancouver	numeric
+Urology Video Journal	2590-0897	elsevier-with-titles	numeric
 Vacuum	0042-207X	elsevier-with-titles	numeric
-The Vaccine Companion	1876-0775	elsevier-vancouver	numeric
-Vaccine Reports	2405-7843	elsevier-with-titles	numeric
 Veterinary and Animal Science	2451-943X	apa	author-date
 Vehicular Communications	2214-2096	elsevier-with-titles	numeric
 Revue vétérinaire Clinique	2214-5672	elsevier-vancouver	numeric
 Veterinary Immunology and Immunopathology	0165-2427	elsevier-harvard	author-date
 Veterinary Microbiology	0378-1135	elsevier-harvard	author-date
 Veterinary Parasitology	0304-4017	elsevier-harvard	author-date
-Value in Health Regional Issues	2212-1099	elsevier-vancouver	numeric
+Value in Health Regional Issues	2212-1099	american-medical-association	numeric
 Vibrational Spectroscopy	0924-2031	elsevier-with-titles	numeric
-Virology Reports	2214-6695	elsevier-harvard	author-date
 Journal of Virological Methods	0166-0934	elsevier-harvard	author-date
 Virus Research	0168-1702	elsevier-harvard	author-date
+Visual Informatics	2468-502X	elsevier-harvard	author-date
 Visual Journal of Emergency Medicine	2405-4690	american-medical-association	numeric
-Video Journal and Encyclopedia of GI Endoscopy	2212-0971	elsevier-vancouver	numeric
-Integration, the VLSI Journal	0167-9260	elsevier-with-titles	numeric
+Integration	0167-9260	elsevier-with-titles	numeric
 Journal of Volcanology and Geothermal Research	0377-0273	elsevier-harvard	author-date
 Vascular Pharmacology	1537-1891	elsevier-with-titles	numeric
+Veterinary Parasitology: X	2590-1389	elsevier-harvard	author-date
 Veterinary Parasitology: Regional Studies and Reports	2405-9390	elsevier-harvard	author-date
 Vision Research	0042-6989	apa	author-date
 Vocation sage-femme	1634-0760	elsevier-vancouver	numeric
 Weather and Climate Extremes	2212-0947	elsevier-harvard	author-date
 Wave Motion	0165-2125	elsevier-with-titles	numeric
+WAO Journal	1939-4551	american-medical-association	numeric
+Water Security	2468-3124	elsevier-with-titles	numeric
 World Development	0305-750X	apa	author-date
 World Development Perspectives	2452-2929	apa	author-date
 Wear	0043-1648	elsevier-with-titles	numeric
-Web Semantics: Science, Services and Agents on the World Wide Web	1570-8268	elsevier-with-titles	numeric
+Journal of Web Semantics	1570-8268	elsevier-with-titles	numeric
 Wilderness & Environmental Medicine	1080-6032	american-medical-association	numeric
+Water-Energy Nexus	2588-9125	elsevier-harvard	author-date
 Wine Economics and Policy	2212-9774	elsevier-harvard	author-date
 Women's Health Issues	1049-3867	apa	author-date
-World Journal of Acupuncture - Moxibustion	1003-5257	elsevier-vancouver-author-date	author-date
+World Journal of Acupuncture - Moxibustion	1003-5257	elsevier-vancouver	numeric
 World Journal of Otorhinolaryngology-Head and Neck Surgery	2095-8811	american-medical-association	numeric
 Waste Management	0956-053X	elsevier-harvard	author-date
 Wound Medicine	2213-9095	elsevier-with-titles	numeric
 World Neurosurgery	1878-8750	american-medical-association	numeric
-Woman - Psychosomatic Gynaecology and Obstetrics	2213-560X	elsevier-harvard	author-date
+World Neurosurgery: X	2590-1397	american-medical-association	numeric
 Journal of World Business	1090-9516	apa	author-date
 World Patent Information	0172-2190	elsevier-with-titles	numeric
-World Psychiatry	1723-8617	american-medical-association	numeric
 Water Research	0043-1354	elsevier-harvard	author-date
 Water Resources and Economics	2212-4284	elsevier-with-titles	numeric
 Water Resources and Industry	2212-3717	elsevier-with-titles	numeric
+Water Research X	2589-9147	elsevier-harvard	author-date
 Water resources and rural development	2212-6082	elsevier-harvard	author-date
 Water Science and Engineering	1674-2370	elsevier-harvard	author-date
+Watershed Ecology and the Environment	2589-4714	elsevier-harvard	author-date
 Women's Studies International Forum	0277-5395	apa	author-date
 Water Science	1110-4929	elsevier-harvard	author-date
 Arthroscopy Techniques	2212-6287	american-medical-association	numeric
@@ -1993,14 +1927,15 @@ Journal of Pharmaceutical Sciences	0022-3549	american-medical-association	numeri
 Archives of Biochemistry and Biophysics	0003-9861	elsevier-with-titles	numeric
 Analytical Biochemistry	0003-2697	elsevier-with-titles	numeric
 Applied and Computational Harmonic Analysis	1063-5203	elsevier-with-titles	numeric
+Advances in Cosmetic Surgery	2542-4327	elsevier-with-titles	numeric
 Atomic Data and Nuclear Data Tables	0092-640X	elsevier-with-titles	numeric
 Annals of Diagnostic Pathology	1092-9134	elsevier-vancouver	numeric
 American Journal of Emergency Medicine	0735-6757	elsevier-vancouver	numeric
 American Journal of Kidney Diseases	0272-6386	american-medical-association	numeric
 American Journal of Otolaryngology--Head and Neck Medicine and Surgery	0196-0709	elsevier-vancouver	numeric
+Advances in Molecular Pathology	2589-4080	elsevier-with-titles	numeric
 Anaerobe	1075-9964	elsevier-with-titles	numeric
 Animal Behaviour	0003-3472	apa	author-date
-Advances in Ophthalmology and Optometry	2452-1760	elsevier-with-titles	numeric
 Annals of Physics	0003-4916	elsevier-with-titles	numeric
 Applied Nursing Research	0897-1897	apa	author-date
 Archives of Psychiatric Nursing	0883-9417	apa	author-date
@@ -2051,6 +1986,7 @@ Epilepsy & Behavior	1525-5050	elsevier-vancouver	numeric
 Estuarine, Coastal and Shelf Science	0272-7714	elsevier-harvard	author-date
 Ecotoxicology and Environmental Safety	0147-6513	elsevier-harvard	author-date
 European Journal of Oncology Nursing	1462-3889	elsevier-harvard	author-date
+European Journal of Surgical Oncology	0748-7983	elsevier-vancouver	numeric
 Environmental Research	0013-9351	elsevier-harvard	author-date
 European Journal of Combinatorics	0195-6698	elsevier-with-titles	numeric
 Experimental Cell Research	0014-4827	elsevier-with-titles	numeric
@@ -2063,9 +1999,10 @@ Finite Fields and Their Applications	1071-5797	elsevier-with-titles	numeric
 Fungal Genetics and Biology	1087-1845	elsevier-harvard	author-date
 Food Microbiology	0740-0020	elsevier-harvard	author-date
 The Foot	0958-2592	elsevier-vancouver	numeric
+Advances in Family Practice Nursing	2589-420X	elsevier-with-titles	numeric
 Frontiers in Neuroendocrinology	0091-3022	elsevier-harvard	author-date
 Fish and Shellfish Immunology	1050-4648	elsevier-with-titles	numeric
-LWT - Food Science and Technology	0023-6438	apa	author-date
+LWT	0023-6438	apa	author-date
 Games and Economic Behavior	0899-8256	elsevier-harvard	author-date
 General and Comparative Endocrinology	0016-6480	elsevier-harvard	author-date
 Genomics	0888-7543	elsevier-with-titles	numeric
@@ -2076,8 +2013,7 @@ Hormones and Behavior	0018-506X	elsevier-harvard	author-date
 Historia Mathematica	0315-0860	elsevier-harvard	author-date
 Human Pathology	0046-8177	elsevier-vancouver	numeric
 Icarus	0019-1035	elsevier-harvard	author-date
-Intensive & Critical Care Nursing	0964-3397	elsevier-vancouver-author-date	author-date
-International Information and Library Review	1057-2317	apa	author-date
+Intensive & Critical Care Nursing	0964-3397	elsevier-harvard	author-date
 International Journal of Human - Computer Studies	1071-5819	elsevier-harvard	author-date
 Information and Computation	0890-5401	elsevier-with-titles	numeric
 Journal of Anthropological Archaeology	0278-4165	elsevier-harvard	author-date
@@ -2088,6 +2024,7 @@ Arthroscopy: The Journal of Arthroscopic and Related Surgery	0749-8063	american-
 Journal of Archaeological Science	0305-4403	elsevier-harvard	author-date
 Journal of Autoimmunity	0896-8411	elsevier-with-titles	numeric
 Journal of Biomedical Informatics	1532-0464	elsevier-with-titles	numeric
+Journal of Biomedical Informatics: X	2590-177X	elsevier-with-titles	numeric
 Journal of Bodywork & Movement Therapies	1360-8592	elsevier-harvard	author-date
 Journal of Catalysis	0021-9517	elsevier-with-titles	numeric
 Journal of Comparative Economics	0147-5967	elsevier-harvard	author-date
@@ -2111,6 +2048,8 @@ Journal of Financial Intermediation	1042-9573	elsevier-harvard	author-date
 Journal of Forensic and Legal Medicine	1752-928X	american-medical-association	numeric
 Journal of Fluids and Structures	0889-9746	elsevier-harvard	author-date
 Journal of Housing Economics	1051-1377	elsevier-harvard	author-date
+Journal of Historical Geography	0305-7488	elsevier-with-titles	numeric
+Journal of Hospital Infection	0195-6701	elsevier-vancouver	numeric
 Journal of Invertebrate Pathology	0022-2011	elsevier-harvard	author-date
 Journal of The Japanese and International Economies	0889-1583	elsevier-harvard	author-date
 Journal of Molecular Biology	0022-2836	elsevier-with-titles	numeric
@@ -2118,7 +2057,7 @@ Journal of Molecular and Cellular Cardiology	0022-2828	elsevier-with-titles	nume
 Journal of Memory and Language	0749-596X	apa	author-date
 Journal of Mathematical Psychology	0022-2496	apa	author-date
 Journal of Magnetic Resonance	1090-7807	elsevier-with-titles	numeric
-Journal of Molecular Spectroscopy	0022-2852	elsevier-without-titles	numeric
+Journal of Molecular Spectroscopy	0022-2852	elsevier-with-titles	numeric
 Journal of Network and Computer Applications	1084-8045	elsevier-harvard	author-date
 Journal of Clinical Neuroscience	0967-5868	elsevier-vancouver	numeric
 Journal of PeriAnesthesia Nursing	1089-9472	american-medical-association	numeric
@@ -2130,6 +2069,7 @@ Journal of Professional Nursing	8755-7223	apa	author-date
 Journal of Pediatric Surgery	0022-3468	elsevier-vancouver	numeric
 Journal of Research in Personality	0092-6566	apa	author-date
 Journal of Structural Biology	1047-8477	elsevier-harvard	author-date
+Journal of Structural Biology: X	2590-1524	elsevier-harvard	author-date
 Journal of Symbolic Computation	0747-7171	elsevier-harvard	author-date
 Journal of Surgical Research	0022-4804	american-medical-association	numeric
 Journal of Solid State Chemistry	0022-4596	elsevier-with-titles	numeric
@@ -2138,10 +2078,8 @@ Journal of Theoretical Biology	0022-5193	elsevier-harvard	author-date
 Journal of Urban Economics	0094-1190	elsevier-harvard	author-date
 Journal of Vocational Behavior	0001-8791	apa	author-date
 Journal of Visual Communication and Image Representation	1047-3203	elsevier-with-titles	numeric
-Journal of Visual Languages and Computing	1045-926X	elsevier-with-titles	numeric
 Learning and Motivation	0023-9690	apa	author-date
 Management Accounting Research	1044-5005	elsevier-harvard	author-date
-Manual Therapy	1356-689X	elsevier-vancouver-author-date	author-date
 Metabolic Engineering	1096-7176	elsevier-harvard	author-date
 Current Problems in Cardiology	0146-2806	american-medical-association	numeric
 Molecular and Cellular Neuroscience	1044-7431	elsevier-harvard	author-date
@@ -2157,7 +2095,7 @@ Methods	1046-2023	elsevier-with-titles	numeric
 Molecular Genetics and Metabolism	1096-7192	elsevier-with-titles	numeric
 Molecular Genetics and Metabolism Reports	2214-4269	elsevier-with-titles	numeric
 Geriatric Nursing	0197-4572	american-medical-association	numeric
-Heart & Lung  - The Journal of Acute and Critical Care	0147-9563	american-medical-association	numeric
+Heart & Lung	0147-9563	american-medical-association	numeric
 Midwifery	0266-6138	elsevier-harvard	author-date
 Journal of the American Academy of Dermatology	0190-9622	american-medical-association	numeric
 Journal of Manipulative and Physiological Therapeutics	0161-4754	american-medical-association	numeric
@@ -2169,37 +2107,38 @@ Journal of Pediatric Health Care	0891-5245	apa	author-date
 Current Problems in Pediatric and Adolescent Health Care	1538-5442	american-medical-association	numeric
 Current Problems in Surgery	0011-3840	american-medical-association	numeric
 Mechanical Systems and Signal Processing	0888-3270	elsevier-with-titles	numeric
+Surgery	0039-6060	american-medical-association	numeric
 The Journal of Thoracic and Cardiovascular Surgery	0022-5223	american-medical-association	numeric
 Journal of Voice	0892-1997	american-medical-association	numeric
 Microvascular Research	0026-2862	elsevier-harvard	author-date
 Neurobiology of Disease	0969-9961	elsevier-harvard	author-date
-Newborn and Infant Nursing Reviews	1527-3369	american-medical-association	numeric
 Nurse Education Today	0260-6917	elsevier-harvard	author-date
 Nurse Education in Practice	1471-5953	elsevier-harvard	author-date
 NeuroImage: Clinical	2213-1582	elsevier-harvard	author-date
 NeuroImage	1053-8119	elsevier-harvard	author-date
 Nitric Oxide	1089-8603	elsevier-with-titles	numeric
 Neurobiology of Learning and Memory	1074-7427	apa	author-date
+Neurobiology of Pain	2452-073X	elsevier-harvard	author-date
 Neuropeptides	0143-4179	elsevier-harvard	author-date
 Neurobiology of Stress	2352-2895	elsevier-harvard	author-date
 Organizational Behavior and Human Decision Processes	0749-5978	apa	author-date
 Optical Fiber Technology	1068-5200	elsevier-with-titles	numeric
 Progress in Cardiovascular Diseases	0033-0620	american-medical-association	numeric
-Pesticide Biochemistry and Physiology	0048-3575	elsevier-with-titles	numeric
+Pesticide Biochemistry and Physiology	0048-3575	elsevier-harvard	author-date
 Pharmacological Research	1043-6618	elsevier-with-titles	numeric
 Placenta	0143-4004	elsevier-with-titles	numeric
 Plasmid	0147-619X	elsevier-harvard	author-date
-Prostaglandins, Leukotrienes and Essential Fatty Acids (PLEFA)	0952-3278	elsevier-with-titles	numeric
+Prostaglandins, Leukotrienes and Essential Fatty Acids	0952-3278	elsevier-with-titles	numeric
 Preventive Medicine	0091-7435	elsevier-harvard	author-date
 Physiological and Molecular Plant Pathology	0885-5765	elsevier-with-titles	numeric
 Protein Expression and Purification	1046-5928	elsevier-with-titles	numeric
 Paediatric Respiratory Reviews	1526-0542	elsevier-vancouver	numeric
 Physical Therapy in Sport	1466-853X	apa	author-date
 Pulmonary Pharmacology & Therapeutics	1094-5539	elsevier-with-titles	numeric
-Quaternary Research	0033-5894	elsevier-harvard	author-date
 Review of Economic Dynamics	1094-2025	elsevier-harvard	author-date
 Research in Economics	1090-9443	elsevier-harvard	author-date
 Respiratory Medicine	0954-6111	elsevier-with-titles	numeric
+Respiratory Medicine: X	2590-1435	elsevier-with-titles	numeric
 Regulatory Toxicology and Pharmacology	0273-2300	elsevier-harvard	author-date
 Research in Veterinary Science	0034-5288	elsevier-harvard	author-date
 Seminars in Arthritis and Rheumatism	0049-0172	elsevier-vancouver	numeric
@@ -2225,10 +2164,8 @@ Techniques in Gastrointestinal Endoscopy	1096-2883	elsevier-vancouver	numeric
 Tissue and Cell	0040-8166	elsevier-harvard	author-date
 Transfusion Medicine Reviews	0887-7963	elsevier-vancouver	numeric
 Theoretical Population Biology	0040-5809	elsevier-harvard	author-date
-Techniques in Regional Anesthesia and Pain Management	1084-208X	american-medical-association	numeric
 Transplantation Reviews	0955-470X	elsevier-vancouver	numeric
 Tuberculosis	1472-9792	elsevier-vancouver	numeric
 The Veterinary Journal	1090-0233	elsevier-harvard	author-date
 Virology	0042-6822	elsevier-harvard	author-date
-Der Zoologische Garten	0044-5169	apa	author-date
 Zoology	0944-2006	elsevier-harvard	author-date


### PR DESCRIPTION
Note that some titles might look incorrect like:
-Analytica Chimica Acta: X
-Respiratory Medicine: X

Those styles are in fact correct and are Open Access mirror of other
journals. See for example.
-https://www.journals.elsevier.com/analytica-chimica-acta-x/
-https://www.journals.elsevier.com/respiratory-medicine-x/