### PR TITLE
Update eslevier _extra.tab to add the-journal-of-pediatric

### DIFF
--- a/elsevier/_extra.tab
+++ b/elsevier/_extra.tab
@@ -3,3 +3,4 @@ Arab Journal of Urology	2090-598X	elsevier-vancouver	numeric
 Healthcare: The Journal of Delivery Science and Innovation	2213-0764	american-medical-association	numeric
 Perspectives in Ecology and Conservation	2530-0644	elsevier-harvard	author-date
 SoftwareX	2352-7110	elsevier-without-titles	numeric
+The Journal of Pediatrics	0022-3476	elsevier-vancouver	numeric


### PR DESCRIPTION
Make "The Journal of Pediatrics" automatically generated and change style to elsevier-vancouver as reported here: 
https://forums.zotero.org/discussion/75142/style-error-the-journal-of-pediatrics

Will the manually generated style be automatically overwritten or do I need to submit another PR to delete it? 
https://github.com/citation-style-language/styles/blob/master/dependent/the-journal-of-pediatrics.csl

edit: I just see that there is another PR submitted adding another journal to the extra.tab. Do I combine these two PRs or can we do them one by one, @rmzelle ?