### PR TITLE
Elsevier: Change parent style for Journal of Orthopaedic Science

### DIFF
--- a/elsevier/_journals.tab
+++ b/elsevier/_journals.tab
@@ -1118,7 +1118,7 @@ Journal of Oncological Sciences	2452-3364	american-medical-association	numeric
 Journal of Orthopaedics	0972-978X	american-medical-association	numeric
 Journal of Stomatology oral and Maxillofacial Surgery	2468-7855	elsevier-vancouver	numeric
 Journal of Outdoor Recreation and Tourism	2213-0780	apa	author-date
-Journal of Orthopaedic Science	0949-2658	elsevier-vancouver	numeric
+Journal of Orthopaedic Science	0949-2658	vancouver-brackets-no-et-al	numeric
 Journal of Orthopaedic Translation	2214-031X	elsevier-vancouver	numeric
 Journal of Otology	1672-2930	elsevier-harvard	author-date
 Joule	2542-4351	elsevier-vancouver	numeric


### PR DESCRIPTION
Change parent style for Journal of Orthopaedic Science to vancouver-brackets-no-et-al.
https://forums.zotero.org/discussion/76790/journal-of-orthopaedic-science-citation-style-modification
@adam3smith as per thread on forum.