### PR TITLE
Create The Optical Society (OSA) dependent journals

### DIFF
--- a/osa/_journals.tab
+++ b/osa/_journals.tab
@@ -9,4 +9,3 @@ Optical Materials Express	OME		2159-3930
 Optics and Photonics News	OPN	1047-6938	1541-3721
 Optics Express	OME 0146-9592	1539-4794
 OSA Continuum OSAC		2578-7519
- 

--- a/osa/_journals.tab
+++ b/osa/_journals.tab
@@ -1,11 +1,10 @@
-TITLE	TITLESHORT	ISSN	eISSN
-Advances in Optics and Photonics	AOP		1943-8206
-Applied Optics	AO	1559-128X	2155-3165
-Biomedical Optics Express	BOE		2156-7085
-Journal of the Optical Society of America A	JOSA A	1084-7529	1520-8532
-Journal of the Optical Society of America B JOSA B	0740-3224	1520-8540
-Optica	2334-2536
-Optical Materials Express	OME		2159-3930
-Optics and Photonics News	OPN	1047-6938	1541-3721
-Optics Express	OME 0146-9592	1539-4794
-OSA Continuum OSAC		2578-7519
+TITLE	TITLESHORT	PARENT  ISSN	eISSN
+Advances in Optics and Photonics	AOP the-optical-society		1943-8206
+Applied Optics	AO  the-optical-society	1559-128X	2155-3165
+Biomedical Optics Express	BOE	optics-express  2156-7085
+Journal of the Optical Society of America A	JOSA A  the-optical-society	1084-7529	1520-8532
+Journal of the Optical Society of America B JOSA B  the-optical-society	0740-3224	1520-8540
+Optica  the-optical-society	2334-2536
+Optical Materials Express	OME optics-express	2159-3930
+Optics and Photonics News	OPN the-optical-society	1047-6938	1541-3721
+OSA Continuum OSAC  the-optical-society		2578-7519

--- a/osa/_journals.tab
+++ b/osa/_journals.tab
@@ -9,3 +9,4 @@ Optical Materials Express	OME		2159-3930
 Optics and Photonics News	OPN	1047-6938	1541-3721
 Optics Express	OME 0146-9592	1539-4794
 OSA Continuum OSAC		2578-7519
+ 

--- a/osa/_journals.tab
+++ b/osa/_journals.tab
@@ -1,0 +1,11 @@
+TITLE	TITLESHORT	ISSN	eISSN
+Advances in Optics and Photonics	AOP		1943-8206
+Applied Optics	AO	1559-128X	2155-3165
+Biomedical Optics Express	BOE		2156-7085
+Journal of the Optical Society of America A	JOSA A	1084-7529	1520-8532
+Journal of the Optical Society of America B JOSA B	0740-3224	1520-8540
+Optica	2334-2536
+Optical Materials Express	OME		2159-3930
+Optics and Photonics News	OPN	1047-6938	1541-3721
+Optics Express	OME 0146-9592	1539-4794
+OSA Continuum OSAC		2578-7519

--- a/osa/_template.csl
+++ b/osa/_template.csl
@@ -6,7 +6,7 @@
     <title-short>#TITLESHORT#</title-short>
     <id>http://www.zotero.org/styles/#IDENTIFIER#</id>
     <link href="http://www.zotero.org/styles/#IDENTIFIER#" rel="self"/>
-    <link href="http://www.zotero.org/styles/the-optical-society" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/#PARENT#" rel="independent-parent"/>
     <link href="https://www.osapublishing.org/about.cfm" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="physics"/>

--- a/osa/_template.csl
+++ b/osa/_template.csl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <!-- #XML-COMMENT# -->
+  <info>
+    <title>#TITLE#</title>
+    <title-short>#TITLESHORT#</title-short>
+    <id>http://www.zotero.org/styles/#IDENTIFIER#</id>
+    <link href="http://www.zotero.org/styles/#IDENTIFIER#" rel="self"/>
+    <link href="http://www.zotero.org/styles/the-optical-society" rel="independent-parent"/>
+    <link href="https://www.osapublishing.org/about.cfm" rel="documentation"/>
+    <category citation-format="numeric"/>
+    <category field="physics"/>
+    <issn>#ISSN#</issn>
+    <eissn>#EISSN#</eissn>
+    <updated>2020-04-01T12:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
Via https://forums.zotero.org/discussion/82127/style-request-optics-letters

We do have two OSA styles already the-optical-society and optics-express.csl.
Optics Express has a slightly different style (see https://github.com/citation-style-language/styles/pull/3300) for the "Express" journals. We have two independent styles biomedical-optics-express.csl and optical-materials-express.csl which will need to be deleted.
