### PR TITLE
Add Clinical & Translational Immunology to NPG_skip.txt

### DIFF
--- a/npg/_skip.txt
+++ b/npg/_skip.txt
@@ -12,5 +12,6 @@ Nature
 SciBX: Science-Business Exchange
 Scientific American
 Scientific American Mind
+Clinical & Translational Immunology
 # Discontinued
 Vital


### PR DESCRIPTION
Add Clinical & Translational Immunology to skip list.
Journal changed from NPG to Wiley. 
See https://forums.zotero.org/discussion/88597/wrong-style-for-clinical-translational-immunology#latest